### PR TITLE
Allow creating new Builders using BaseMessageBuilder

### DIFF
--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
@@ -77,7 +77,7 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
      * 
      * @return the JMS message
      */
-    abstract Message getJMSMessage(JMSContext jmsCtxt, SinkRecord record);
+    public abstract Message getJMSMessage(JMSContext jmsCtxt, SinkRecord record);
 
    /**
      * Convert a Kafka Connect SinkRecord into a JMS message.


### PR DESCRIPTION
The current `BaseMessageBuilder` interface defines some abstract methods,
without declaring their visibility.

This means it is by default, they are `package-private`, and we can't
create sub-classes extending the behavior.

One scenario where extending from another package is ideal would be when
extra headers are required to be sent to MQ. This commit changes the
modifier to be public so others could extend them.

Similar to https://github.com/ibm-messaging/kafka-connect-mq-source/pull/26