### PR TITLE
Create new parameter "mq.encoding" to override the destination character set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=esuser:esgroup --from=builder /opt/kafka/libs/ /opt/kafka/libs/
 COPY --chown=esuser:esgroup --from=builder /opt/kafka/config/connect-distributed.properties /opt/kafka/config/
 COPY --chown=esuser:esgroup --from=builder /opt/kafka/config/connect-log4j.properties /opt/kafka/config/
 RUN mkdir /opt/kafka/logs && chown esuser:esgroup /opt/kafka/logs
-COPY --chown=esuser:esgroup target/kafka-connect-mq-sink-1.3.1-jar-with-dependencies.jar /opt/kafka/libs/
+COPY --chown=esuser:esgroup target/kafka-connect-mq-sink-1.3.2-jar-with-dependencies.jar /opt/kafka/libs/
 
 WORKDIR /opt/kafka
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>com.ibm.eventstreams.connect</groupId>
   <artifactId>kafka-connect-mq-sink</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <name>kafka-connect-mq-sink</name>
   <organization>
     <name>IBM Corporation</name>

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
@@ -332,7 +332,7 @@ public class MQSinkConnector extends SinkConnector {
                       CONFIG_DOCUMENTATION_MQ_SSL_USE_IBM_CIPHER_MAPPINGS, CONFIG_GROUP_MQ, 26, Width.SHORT,
                       CONFIG_DISPLAY_MQ_SSL_USE_IBM_CIPHER_MAPPINGS);
 
-        config.define(CONFIG_NAME_MQ_ENCODING, Type.BOOLEAN, null, Importance.LOW,
+        config.define(CONFIG_NAME_MQ_ENCODING, Type.STRING, null, Importance.LOW,
                       CONFIG_DOCUMENTATION_MQ_ENCODING, CONFIG_GROUP_MQ, 27, Width.SHORT,
                       CONFIG_DISPLAY_MQ_ENCODING);
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
@@ -66,6 +66,10 @@ public class MQSinkConnector extends SinkConnector {
     public static final String CONFIG_DOCUMENTATION_MQ_PASSWORD = "The password for authenticating with the queue manager.";
     public static final String CONFIG_DISPLAY_MQ_PASSWORD = "Password";
 
+    public static final String CONFIG_NAME_MQ_ENCODING = "mq.encoding";
+    public static final String CONFIG_DOCUMENTATION_MQ_ENCODING = "The encoding can be replaced in queue manager.";
+    public static final String CONFIG_DISPLAY_MQ_ENCODING = "Encoding";
+
     public static final String CONFIG_NAME_MQ_CCDT_URL = "mq.ccdt.url"; 
     public static final String CONFIG_DOCUMENTATION_MQ_CCDT_URL = "The CCDT URL to use to establish a connection to the queue manager.";
     public static final String CONFIG_DISPLAY_MQ_CCDT_URL = "CCDT URL";
@@ -143,7 +147,7 @@ public class MQSinkConnector extends SinkConnector {
     public static final String CONFIG_DOCUMENTATION_MQ_USER_AUTHENTICATION_MQCSP = "Whether to use MQ connection security parameters (MQCSP).";
     public static final String CONFIG_DISPLAY_MQ_USER_AUTHENTICATION_MQCSP = "User authentication using MQCSP";
 
-    public static String VERSION = "1.3.1";
+    public static String VERSION = "1.3.2";
 
     private Map<String, String> configProps;
 
@@ -327,6 +331,10 @@ public class MQSinkConnector extends SinkConnector {
         config.define(CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS, Type.BOOLEAN, null, Importance.LOW,
                       CONFIG_DOCUMENTATION_MQ_SSL_USE_IBM_CIPHER_MAPPINGS, CONFIG_GROUP_MQ, 26, Width.SHORT,
                       CONFIG_DISPLAY_MQ_SSL_USE_IBM_CIPHER_MAPPINGS);
+
+        config.define(CONFIG_NAME_MQ_ENCODING, Type.BOOLEAN, null, Importance.LOW,
+                      CONFIG_DOCUMENTATION_MQ_ENCODING, CONFIG_GROUP_MQ, 27, Width.SHORT,
+                      CONFIG_DISPLAY_MQ_ENCODING);
 
         return config;
     }


### PR DESCRIPTION
According to the website: [jms encoding](https://www.ibm.com/docs/en/ibm-mq/7.5?topic=conversion-jms-client-message-encoding)

"An application can override the destination character set by setting the message property JMS_IBM_CHARACTER_SET. JMS_IBM_CHARACTER_SET, when sending a message must be a numeric coded character set identifier2."