### PR TITLE
fix: Fix deprecated set-env and update java version.

### DIFF
--- a/.github/workflows/github-build-release.yml
+++ b/.github/workflows/github-build-release.yml
@@ -12,15 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 8
+          distribution: 'temurin'
       - name: Get java-version
         run: |
           BUILD_VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
-          echo "::set-env name=VERSION::$BUILD_VERSION"
+          echo "VERSION=$BUILD_VERSION" >> $GITHUB_ENV
       - name: Build
         run: mvn package
       - name: Create Release
@@ -33,8 +34,8 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset 
+      - name: Upload Release Asset With Dependencies
+        id: upload-release-asset-with-dependencies
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,4 +43,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./target/kafka-connect-mq-sink-${{env.VERSION}}-jar-with-dependencies.jar
           asset_name: kafka-connect-mq-sink-${{env.VERSION}}-jar-with-dependencies.jar
+          asset_content_type: application/java-archive
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/kafka-connect-mq-sink-${{env.VERSION}}.jar
+          asset_name: kafka-connect-mq-sink-${{env.VERSION}}.jar
           asset_content_type: application/java-archive


### PR DESCRIPTION
- Update set-env way to setting environment variables.
- Update java to version 8 distribution temurin
- Add a additional asset kafka-connect-mq-sink-VERSION.jar

Github action ran successfully

![image](https://user-images.githubusercontent.com/17215044/225002213-77783026-7b2e-498f-b08a-02c2daf55b26.png)

Sample release

![image](https://user-images.githubusercontent.com/17215044/225002240-998f64fe-428a-4b5f-9a28-1f1b7724e4fe.png)
