### PR TITLE
feat: support for copying Kafka headers to MQ message properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=esuser:esgroup --from=builder /opt/kafka/libs/ /opt/kafka/libs/
 COPY --chown=esuser:esgroup --from=builder /opt/kafka/config/connect-distributed.properties /opt/kafka/config/
 COPY --chown=esuser:esgroup --from=builder /opt/kafka/config/connect-log4j.properties /opt/kafka/config/
 RUN mkdir /opt/kafka/logs && chown esuser:esgroup /opt/kafka/logs
-COPY --chown=esuser:esgroup target/kafka-connect-mq-sink-1.3.1-jar-with-dependencies.jar /opt/kafka/libs/
+COPY --chown=esuser:esgroup target/kafka-connect-mq-sink-1.4.0-jar-with-dependencies.jar /opt/kafka/libs/
 
 WORKDIR /opt/kafka
 

--- a/README.md
+++ b/README.md
@@ -282,35 +282,36 @@ For troubleshooting, or to better understand the handshake performed by the IBM 
 ## Configuration
 The configuration options for the Kafka Connect sink connector for IBM MQ are as follows:
 
-| Name                                  | Description                                                            | Type    | Default        | Valid values                      |
-| ------------------------------------- | ---------------------------------------------------------------------- | ------- | -------------- | --------------------------------- |
-| topics or topics.regex                | List of Kafka source topics                                            | string  |                | topic1[,topic2,...]               |
-| mq.queue.manager                      | The name of the MQ queue manager                                       | string  |                | MQ queue manager name             |
-| mq.connection.mode                    | The connection mode - bindings or client                               | string  | client         | client, bindings                  |
-| mq.connection.name.list               | List of connection names for queue manager                             | string  |                | host(port)[,host(port),...]       |
-| mq.channel.name                       | The name of the server-connection channel                              | string  |                | MQ channel name                   |
-| mq.queue                              | The name of the target MQ queue                                        | string  |                | MQ queue name                     |
-| mq.user.name                          | The user name for authenticating with the queue manager                | string  |                | User name                         |
-| mq.password                           | The password for authenticating with the queue manager                 | string  |                | Password                          |
-| mq.user.authentication.mqcsp          | Whether to use MQ connection security parameters (MQCSP)               | boolean | true           |                                   |
-| mq.ccdt.url                           | The URL for the CCDT file containing MQ connection details             | string  |                | URL for obtaining a CCDT file     |
-| mq.message.builder                    | The class used to build the MQ message                                 | string  |                | Class implementing MessageBuilder |
-| mq.message.body.jms                   | Whether to generate the message body as a JMS message type             | boolean | false          |                                   |
-| mq.time.to.live                       | Time-to-live in milliseconds for messages sent to MQ                   | long    | 0 (unlimited)  | [0,...]                           |
-| mq.persistent                         | Send persistent or non-persistent messages to MQ                       | boolean | true           |                                   |
-| mq.ssl.cipher.suite                   | The name of the cipher suite for TLS (SSL) connection                  | string  |                | Blank or valid cipher suite       |
-| mq.ssl.peer.name                      | The distinguished name pattern of the TLS (SSL) peer                   | string  |                | Blank or DN pattern               |
-| mq.ssl.keystore.location              | The path to the JKS keystore to use for SSL (TLS) connections          | string  | JVM keystore   | Local path to a JKS file          |
-| mq.ssl.keystore.password              | The password of the JKS keystore to use for SSL (TLS) connections      | string  |                |                                   |
-| mq.ssl.truststore.location            | The path to the JKS truststore to use for SSL (TLS) connections        | string  | JVM truststore | Local path to a JKS file          |
-| mq.ssl.truststore.password            | The password of the JKS truststore to use for SSL (TLS) connections    | string  |                |                                   |
-| mq.ssl.use.ibm.cipher.mappings        | Whether to set system property to control use of IBM cipher mappings   | boolean |                |                                   |
-| mq.message.builder.key.header         | The JMS message header to set from the Kafka record key                | string  |                | JMSCorrelationID                  |
-| mq.message.builder.value.converter    | The class and prefix for message builder's value converter             | string  |                | Class implementing Converter      |
-| mq.message.builder.topic.property     | The JMS message property to set from the Kafka topic                   | string  |                | Blank or valid JMS property name  |
-| mq.message.builder.partition.property | The JMS message property to set from the Kafka partition               | string  |                | Blank or valid JMS property name  |
-| mq.message.builder.offset.property    | The JMS message property to set from the Kafka offset                  | string  |                | Blank or valid JMS property name  |
-| mq.reply.queue                        | The name of the reply-to queue                                         | string  |                | MQ queue name or queue URI        |
+| Name                                    | Description                                                            | Type    | Default        | Valid values                      |
+| --------------------------------------- | ---------------------------------------------------------------------- | ------- | -------------- | --------------------------------- |
+| topics or topics.regex                  | List of Kafka source topics                                            | string  |                | topic1[,topic2,...]               |
+| mq.queue.manager                        | The name of the MQ queue manager                                       | string  |                | MQ queue manager name             |
+| mq.connection.mode                      | The connection mode - bindings or client                               | string  | client         | client, bindings                  |
+| mq.connection.name.list                 | List of connection names for queue manager                             | string  |                | host(port)[,host(port),...]       |
+| mq.channel.name                         | The name of the server-connection channel                              | string  |                | MQ channel name                   |
+| mq.queue                                | The name of the target MQ queue                                        | string  |                | MQ queue name                     |
+| mq.user.name                            | The user name for authenticating with the queue manager                | string  |                | User name                         |
+| mq.password                             | The password for authenticating with the queue manager                 | string  |                | Password                          |
+| mq.user.authentication.mqcsp            | Whether to use MQ connection security parameters (MQCSP)               | boolean | true           |                                   |
+| mq.ccdt.url                             | The URL for the CCDT file containing MQ connection details             | string  |                | URL for obtaining a CCDT file     |
+| mq.message.builder                      | The class used to build the MQ message                                 | string  |                | Class implementing MessageBuilder |
+| mq.message.body.jms                     | Whether to generate the message body as a JMS message type             | boolean | false          |                                   |
+| mq.time.to.live                         | Time-to-live in milliseconds for messages sent to MQ                   | long    | 0 (unlimited)  | [0,...]                           |
+| mq.persistent                           | Send persistent or non-persistent messages to MQ                       | boolean | true           |                                   |
+| mq.ssl.cipher.suite                     | The name of the cipher suite for TLS (SSL) connection                  | string  |                | Blank or valid cipher suite       |
+| mq.ssl.peer.name                        | The distinguished name pattern of the TLS (SSL) peer                   | string  |                | Blank or DN pattern               |
+| mq.ssl.keystore.location                | The path to the JKS keystore to use for SSL (TLS) connections          | string  | JVM keystore   | Local path to a JKS file          |
+| mq.ssl.keystore.password                | The password of the JKS keystore to use for SSL (TLS) connections      | string  |                |                                   |
+| mq.ssl.truststore.location              | The path to the JKS truststore to use for SSL (TLS) connections        | string  | JVM truststore | Local path to a JKS file          |
+| mq.ssl.truststore.password              | The password of the JKS truststore to use for SSL (TLS) connections    | string  |                |                                   |
+| mq.ssl.use.ibm.cipher.mappings          | Whether to set system property to control use of IBM cipher mappings   | boolean |                |                                   |
+| mq.message.builder.key.header           | The JMS message header to set from the Kafka record key                | string  |                | JMSCorrelationID                  |
+| mq.kafka.headers.copy.to.jms.properties | Whether to copy Kafka headers to JMS message properties                | boolean | false          |                                   |
+| mq.message.builder.value.converter      | The class and prefix for message builder's value converter             | string  |                | Class implementing Converter      |
+| mq.message.builder.topic.property       | The JMS message property to set from the Kafka topic                   | string  |                | Blank or valid JMS property name  |
+| mq.message.builder.partition.property   | The JMS message property to set from the Kafka partition               | string  |                | Blank or valid JMS property name  |
+| mq.message.builder.offset.property      | The JMS message property to set from the Kafka offset                  | string  |                | Blank or valid JMS property name  |
+| mq.reply.queue                          | The name of the reply-to queue                                         | string  |                | MQ queue name or queue URI        |
 
 
 ### Using a CCDT file

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ curl -X POST -H "Content-Type: application/json" http://localhost:8083/connector
 This repository includes an example Dockerfile to run Kafka Connect in distributed mode. It also adds in the MQ sink connector as an available connector plugin. It uses the default `connect-distributed.properties` and `connect-log4j.properties` files.
 
 1. `mvn clean package`
-1. `docker build -t kafkaconnect-with-mq-sink:1.3.0 .`
-1. `docker run -p 8083:8083 kafkaconnect-with-mq-sink:1.3.0`
+1. `docker build -t kafkaconnect-with-mq-sink:1.4.0 .`
+1. `docker run -p 8083:8083 kafkaconnect-with-mq-sink:1.4.0`
 
 **NOTE:** To provide custom properties files create a folder called `config` containing the `connect-distributed.properties` and `connect-log4j.properties` files and use a Docker volume to make them available when running the container like this:
 
 ``` shell
-docker run -v $(pwd)/config:/opt/kafka/config -p 8083:8083 kafkaconnect-with-mq-sink:1.3.0
+docker run -v $(pwd)/config:/opt/kafka/config -p 8083:8083 kafkaconnect-with-mq-sink:1.4.0
 ```
 
 To start the MQ connector, you can use `config/mq-sink.json` in this repository after replacing all placeholders and use a command like this:

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>com.ibm.eventstreams.connect</groupId>
   <artifactId>kafka-connect-mq-sink</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.1</version>
+  <version>1.4.0</version>
   <name>kafka-connect-mq-sink</name>
   <organization>
     <name>IBM Corporation</name>

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/AbstractJMSContextIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/AbstractJMSContextIT.java
@@ -104,7 +104,7 @@ public abstract class AbstractJMSContextIT {
     private void waitForQueueManagerStartup() throws TimeoutException {
         WaitingConsumer logConsumer = new WaitingConsumer();
         MQ_CONTAINER.followOutput(logConsumer);
-        logConsumer.waitUntil(logline -> logline.getUtf8String().contains("AMQ5975I"));
+        logConsumer.waitUntil(logline -> logline.getUtf8String().contains("AMQ5806I: Queued Publish/Subscribe Daemon started for queue manager"));
     }
 
 

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskAuthIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskAuthIT.java
@@ -95,7 +95,7 @@ public class MQSinkTaskAuthIT {
     private void waitForQueueManagerStartup() throws TimeoutException {
         WaitingConsumer logConsumer = new WaitingConsumer();
         MQ_CONTAINER.followOutput(logConsumer);
-        logConsumer.waitUntil(logline -> logline.getUtf8String().contains("AMQ5975I"));
+        logConsumer.waitUntil(logline -> logline.getUtf8String().contains("AMQ5806I: Queued Publish/Subscribe Daemon started for queue manager"));
     }
 
     private List<Message> getAllMessagesFromQueue() throws JMSException {

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderIT.java
@@ -121,7 +121,8 @@ public class DefaultMessageBuilderIT extends AbstractJMSContextIT {
 
     private void createAndVerifyIntegerMessage(Schema valueSchema, Integer value) throws Exception {
         Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(valueSchema, value));
-        assertEquals(value, new Integer(message.getBody(String.class)));
+        Integer intValue = Integer.parseInt(message.getBody(String.class));
+        assertEquals(value, intValue);
     }
 
     private void createAndVerifyByteMessage(Schema valueSchema, Object value, String valueAsString) throws Exception {

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderWithHeadersIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderWithHeadersIT.java
@@ -58,9 +58,17 @@ public class DefaultMessageBuilderWithHeadersIT extends AbstractJMSContextIT {
                               headers);
     }
 
-
     @Test
-    public void buildMessageWithMultipleHeaders() throws Exception {
+    public void buildMessageWithNoHeaders() throws Exception {
+        // generate MQ message
+        Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(null));
+
+        // verify there are no MQ message properties
+        assertFalse(message.getPropertyNames().hasMoreElements());
+    }
+    
+    @Test
+    public void buildMessageWithStringHeaders() throws Exception {
         Map<String, String> testHeaders = new HashMap<>();
         testHeaders.put("HeaderOne",   "This is test header one");
         testHeaders.put("HeaderTwo",   "This is test header two");

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderWithHeadersIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderWithHeadersIT.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2023 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.Message;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.eventstreams.connect.mqsink.AbstractJMSContextIT;
+
+public class DefaultMessageBuilderWithHeadersIT extends AbstractJMSContextIT {
+
+    private MessageBuilder builder;
+
+    @Before
+    public void prepareMessageBuilder() {
+        builder = new DefaultMessageBuilder();
+
+        Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        builder.configure(props);
+    }
+
+    private SinkRecord generateSinkRecord(ConnectHeaders headers) {
+        final String TOPIC = "TOPIC.NAME";
+        final int PARTITION = 0;
+        final long OFFSET = 0;
+        return new SinkRecord(TOPIC, PARTITION,
+                              Schema.STRING_SCHEMA, "mykey",
+                              Schema.STRING_SCHEMA, "Test message",
+                              OFFSET,
+                              null, TimestampType.NO_TIMESTAMP_TYPE,
+                              headers);
+    }
+
+
+    @Test
+    public void buildMessageWithMultipleHeaders() throws Exception {
+        Map<String, String> testHeaders = new HashMap<>();
+        testHeaders.put("HeaderOne",   "This is test header one");
+        testHeaders.put("HeaderTwo",   "This is test header two");
+        testHeaders.put("HeaderThree", "This is test header three");
+        testHeaders.put("HeaderFour",  "This is test header four");
+
+        // prepare Kafka headers for input message
+        ConnectHeaders headers = new ConnectHeaders();
+        for (String key : testHeaders.keySet()) {
+            headers.addString(key, testHeaders.get(key));
+        }
+
+        // generate MQ message
+        Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // verify MQ message properties
+        for (String key : testHeaders.keySet()) {
+            assertEquals(testHeaders.get(key), message.getStringProperty(key));
+        }
+    }
+
+    @Test
+    public void buildMessageWithBooleanHeaders() throws Exception {
+        // prepare Kafka headers for input message
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addBoolean("TestTrue",  true);
+        headers.addBoolean("TestFalse", false);
+
+        // generate MQ message
+        Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // verify MQ message properties
+        assertEquals("true",  message.getStringProperty("TestTrue"));
+        assertEquals("false", message.getStringProperty("TestFalse"));
+        assertTrue(message.getBooleanProperty("TestTrue"));
+        assertFalse(message.getBooleanProperty("TestFalse"));
+    }
+
+    @Test
+    public void buildMessageWithIntegerHeaders() throws Exception {
+        // prepare Kafka headers for input message
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addInt("TestOne",   1);
+        headers.addInt("TestTwo",   2);
+        headers.addInt("TestThree", 3);
+
+        // generate MQ message
+        Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // verify MQ message properties
+        assertEquals("1", message.getStringProperty("TestOne"));
+        assertEquals("2", message.getStringProperty("TestTwo"));
+        assertEquals("3", message.getStringProperty("TestThree"));
+        assertEquals(1, message.getIntProperty("TestOne"));
+        assertEquals(2, message.getIntProperty("TestTwo"));
+        assertEquals(3, message.getIntProperty("TestThree"));
+    }
+
+    @Test
+    public void buildMessageWithDoubleHeaders() throws Exception {
+        // prepare Kafka headers for input message
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addDouble("TestPi", 3.14159265359);
+
+        // generate MQ message
+        Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // verify MQ message properties
+        assertEquals("3.14159265359", message.getStringProperty("TestPi"));
+        assertEquals(3.14159265359, message.getDoubleProperty("TestPi"), 0.0000000001);
+    }
+}

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
@@ -143,6 +143,10 @@ public class MQSinkConnector extends SinkConnector {
     public static final String CONFIG_DOCUMENTATION_MQ_USER_AUTHENTICATION_MQCSP = "Whether to use MQ connection security parameters (MQCSP).";
     public static final String CONFIG_DISPLAY_MQ_USER_AUTHENTICATION_MQCSP = "User authentication using MQCSP";
 
+    public static final String CONFIG_NAME_KAFKA_HEADERS_COPY_TO_JMS_PROPERTIES = "mq.kafka.headers.copy.to.jms.properties";
+    public static final String CONFIG_DOCUMENTATION_KAFKA_HEADERS_COPY_TO_JMS_PROPERTIES = "Whether to copy Kafka headers to JMS message properties.";
+    public static final String CONFIG_DISPLAY_KAFKA_HEADERS_COPY_TO_JMS_PROPERTIES = "Copy Kafka headers to JMS message properties";
+
     public static String VERSION = "1.4.0";
 
     private Map<String, String> configProps;
@@ -327,6 +331,10 @@ public class MQSinkConnector extends SinkConnector {
         config.define(CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS, Type.BOOLEAN, null, Importance.LOW,
                       CONFIG_DOCUMENTATION_MQ_SSL_USE_IBM_CIPHER_MAPPINGS, CONFIG_GROUP_MQ, 26, Width.SHORT,
                       CONFIG_DISPLAY_MQ_SSL_USE_IBM_CIPHER_MAPPINGS);
+
+        config.define(CONFIG_NAME_KAFKA_HEADERS_COPY_TO_JMS_PROPERTIES, Type.BOOLEAN, null, Importance.LOW,
+                      CONFIG_DOCUMENTATION_KAFKA_HEADERS_COPY_TO_JMS_PROPERTIES, CONFIG_GROUP_MQ, 27, Width.SHORT,
+                      CONFIG_DISPLAY_KAFKA_HEADERS_COPY_TO_JMS_PROPERTIES);
 
         return config;
     }

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
@@ -143,7 +143,7 @@ public class MQSinkConnector extends SinkConnector {
     public static final String CONFIG_DOCUMENTATION_MQ_USER_AUTHENTICATION_MQCSP = "Whether to use MQ connection security parameters (MQCSP).";
     public static final String CONFIG_DISPLAY_MQ_USER_AUTHENTICATION_MQCSP = "User authentication using MQCSP";
 
-    public static String VERSION = "1.3.1";
+    public static String VERSION = "1.4.0";
 
     private Map<String, String> configProps;
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
@@ -20,7 +20,7 @@ import com.ibm.eventstreams.connect.mqsink.MQSinkConnector;
 import com.ibm.mq.jms.*;
 
 import java.nio.ByteBuffer;
-
+import java.util.Iterator;
 import java.util.Map;
 
 import javax.jms.Destination;
@@ -31,6 +31,7 @@ import javax.jms.Message;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.slf4j.Logger;
@@ -48,6 +49,7 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
     public String topicPropertyName;
     public String partitionPropertyName;
     public String offsetPropertyName;
+    public boolean copyJmsProperties;
 
     /**
      * Configure this class.
@@ -100,6 +102,11 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
         String opn = props.get(MQSinkConnector.CONFIG_NAME_MQ_MESSAGE_BUILDER_OFFSET_PROPERTY);
         if (opn != null) {
             offsetPropertyName = opn;
+        }
+        
+        String copyhdr = props.get(MQSinkConnector.CONFIG_NAME_KAFKA_HEADERS_COPY_TO_JMS_PROPERTIES);
+        if (copyhdr != null) {
+            copyJmsProperties = Boolean.valueOf(copyhdr);
         }
 
         log.trace("[{}]  Exit {}.configure", Thread.currentThread().getId(), this.getClass().getName());
@@ -221,6 +228,18 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
             catch (JMSException jmse) {
                 throw new ConnectException("Failed to set offset property", jmse);
             }
+        }
+        
+        if (copyJmsProperties) {
+            for (Iterator<Header> iterator = record.headers().iterator(); iterator.hasNext();) {
+    			Header header = iterator.next();
+    			try {
+                    m.setStringProperty(header.key(), header.value().toString());
+                } 
+    			catch (JMSException jmse) {
+                    throw new ConnectException("Failed to set header", jmse);
+                }
+    		}
         }
 
         return m;

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
@@ -229,17 +229,17 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
                 throw new ConnectException("Failed to set offset property", jmse);
             }
         }
-        
+
         if (copyJmsProperties) {
             for (Iterator<Header> iterator = record.headers().iterator(); iterator.hasNext();) {
-    			Header header = iterator.next();
-    			try {
+                Header header = iterator.next();
+                try {
                     m.setStringProperty(header.key(), header.value().toString());
-                } 
-    			catch (JMSException jmse) {
+                }
+                catch (JMSException jmse) {
                     throw new ConnectException("Failed to set header", jmse);
                 }
-    		}
+            }
         }
 
         return m;


### PR DESCRIPTION
This pull request introduces a new feature to the MQ Sink Connector.
If enabled, all headers on messages consumed from Kafka will be added to
messages put to MQ as string properties.

The feature is named to be consistent with the equivalent feature in
the MQ Source Connector (`mq.kafka.headers.copy.to.jms.properties` where
the Source Connector currently has 
`mq.jms.properties.copy.to.kafka.headers`)

The new feature is disabled by default to maintain compatibility with
current behaviour.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>