### PR TITLE
docs: mq-sink task might fail due to missing authentication settings or incorrect group.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ bin/connect-standalone.sh connect-standalone.properties mq-sink.properties
 
 You need an instance of Kafka Connect running in distributed mode. The Kafka distribution includes a file called `connect-distributed.properties` that you can use as a starting point, or follow [Running with Docker](#running-with-docker) or [Deploying to Kubernetes](#deploying-to-kubernetes).
 
+Note: As applicable, add below consumer properties for authentication in `connect-distributed.properties` so that mq-sink task can access kafka topic to read data
+
+``` shell
+# Sink authentication settings
+consumer.security.protocol=
+consumer.ssl.truststore.location=
+consumer.ssl.truststore.password=
+consumer.ssl.keystore.location=
+consumer.ssl.keystore.password=
+```
+
+Note: By default, kafka connect uses a group.id starting with connect-{connector name}
+To override group.id, use below property in mq-sink.json
+``` shell
+"consumer.override.group.id": "group id name"
+```
+
 To start the MQ connector, you can use `config/mq-sink.json` in this repository after replacing all placeholders and use a command like this:
 
 ``` shell


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

By default, `connect-distributed.properties` has only authentication settings for mq-source. 
So have added a note so that settings can be added for mq-sink which will help beginners.

In big enterprises, group.id might have to follow a prefix or pattern. In those scenarios, using the override property will help beginners avoid issues due to that.

Fixes # (issue)

## Type of change

- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code