### PR TITLE
build: download kafka 3.4.1 from archive.apache.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine as builder
 RUN apk update
 RUN apk --no-cache add curl
 
-RUN curl -L "https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz" -o kafka.tgz
+RUN curl -L "https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz" -o kafka.tgz
 
 RUN mkdir /opt/kafka \
     && tar -xf kafka.tgz -C /opt/kafka --strip-components=1


### PR DESCRIPTION
# Description

The docker build on main currently fails. The kafka 3.4.1 release has been moved to their archive domain, so we can pull the tarball from there.

```
 > [builder 5/5] RUN mkdir /opt/kafka     && tar -xf kafka.tgz -C /opt/kafka --strip-components=1:
0.182 tar: invalid tar magic
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] E2E
- [ ] Unit Test
- [ ] Integration Test

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules