### PR TITLE
fixing exception when setting mq.ssl.use.ibm.cipher.mappings for mq sink connector

### DIFF
--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
@@ -131,13 +131,13 @@ public class MQSinkTaskIT extends AbstractJMSContextIT {
     public void verifyCipherMappingsConfig() throws JMSException {
         final MQSinkTask newConnectTask = new MQSinkTask();
 
-        // configure a sink task for string messages
+        // configure a sink task for validating config
         final Map<String, String> connectorConfigProps = createDefaultConnectorProperties();
         connectorConfigProps.put("mq.message.builder",
                 DEFAULT_MESSAGE_BUILDER);
 
         connectorConfigProps.put("mq.ssl.use.ibm.cipher.mappings",
-                "true");        
+                "true");       
 
         // start the task so that it connects to MQ
         newConnectTask.start(connectorConfigProps);
@@ -148,6 +148,19 @@ public class MQSinkTaskIT extends AbstractJMSContextIT {
 
         // stop the task
         newConnectTask.stop();
+
+        // configure a sink task for validating config for failure case
+        connectorConfigProps.put("mq.message.builder",
+                DEFAULT_MESSAGE_BUILDER);
+
+        connectorConfigProps.put("mq.ssl.use.ibm.cipher.mappings",
+                "hello");       
+
+        // Verify the exception messages
+        final ConfigException exc = assertThrows(ConfigException.class, () -> {
+            newConnectTask.start(connectorConfigProps);
+        });
+        assertEquals("Invalid value hello for configuration mq.ssl.use.ibm.cipher.mappings: Expected value to be either true or false", exc.getMessage());
     }
 
     @Test

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
@@ -128,7 +128,7 @@ public class MQSinkTaskIT extends AbstractJMSContextIT {
     }
 
     @Test
-    public void verifyMqConfig() throws JMSException {
+    public void verifyCipherMappingsConfig() throws JMSException {
         final MQSinkTask newConnectTask = new MQSinkTask();
 
         // configure a sink task for string messages
@@ -142,27 +142,12 @@ public class MQSinkTaskIT extends AbstractJMSContextIT {
         // start the task so that it connects to MQ
         newConnectTask.start(connectorConfigProps);
 
-        // create some test messages
-        final List<SinkRecord> records = new ArrayList<>();
-        records.add(generateSinkRecord(null, "hello"));
-        records.add(generateSinkRecord(null, "world"));
-        newConnectTask.put(records);
-
-        // flush the messages
-        final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
-        final TopicPartition topic = new TopicPartition(TOPIC, PARTITION);
-        final OffsetAndMetadata offset = new OffsetAndMetadata(commonOffset);
-        offsets.put(topic, offset);
-        newConnectTask.flush(offsets);
+        // Check if the config reflects the change
+        String cipherMappingProp = System.getProperty("com.ibm.mq.cfg.useIBMCipherMappings");
+        assertEquals("true", cipherMappingProp);
 
         // stop the task
         newConnectTask.stop();
-
-        // verify that the messages were successfully submitted to MQ
-        final List<Message> messagesInMQ = getAllMessagesFromQueue(DEFAULT_SINK_QUEUE_NAME);
-        assertEquals(2, messagesInMQ.size());
-        assertEquals("hello", messagesInMQ.get(0).getBody(String.class));
-        assertEquals("world", messagesInMQ.get(1).getBody(String.class));
     }
 
     @Test

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
@@ -127,40 +127,25 @@ public class MQSinkTaskIT extends AbstractJMSContextIT {
         assertEquals("world", messagesInMQ.get(1).getBody(String.class));
     }
 
-    @Test
-    public void verifyCipherMappingsConfig() throws JMSException {
-        final MQSinkTask newConnectTask = new MQSinkTask();
-
-        // configure a sink task for validating config
+     @Test
+    public void verifyMQSslUseIbmCipherMappings() {
         final Map<String, String> connectorConfigProps = createDefaultConnectorProperties();
         connectorConfigProps.put("mq.message.builder",
                 DEFAULT_MESSAGE_BUILDER);
+        connectorConfigProps.put("mq.ssl.use.ibm.cipher.mappings", "true");
 
-        connectorConfigProps.put("mq.ssl.use.ibm.cipher.mappings",
-                "true");       
-
-        // start the task so that it connects to MQ
+        final MQSinkTask newConnectTask = new MQSinkTask();
         newConnectTask.start(connectorConfigProps);
 
         // Check if the config reflects the change
-        String cipherMappingProp = System.getProperty("com.ibm.mq.cfg.useIBMCipherMappings");
-        assertEquals("true", cipherMappingProp);
-
-        // stop the task
-        newConnectTask.stop();
-
-        // configure a sink task for validating config for failure case
-        connectorConfigProps.put("mq.message.builder",
-                DEFAULT_MESSAGE_BUILDER);
-
-        connectorConfigProps.put("mq.ssl.use.ibm.cipher.mappings",
-                "hello");       
-
+        assertEquals(System.getProperty("com.ibm.mq.cfg.useIBMCipherMappings"), "true");
+        
         // Verify the exception messages
+        connectorConfigProps.put("mq.ssl.use.ibm.cipher.mappings", "Not a boolean");
         final ConfigException exc = assertThrows(ConfigException.class, () -> {
             newConnectTask.start(connectorConfigProps);
         });
-        assertEquals("Invalid value hello for configuration mq.ssl.use.ibm.cipher.mappings: Expected value to be either true or false", exc.getMessage());
+        assertEquals("Invalid value Not a boolean for configuration mq.ssl.use.ibm.cipher.mappings: Expected value to be either true or false", exc.getMessage());
     }
 
     @Test

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskIT.java
@@ -128,6 +128,44 @@ public class MQSinkTaskIT extends AbstractJMSContextIT {
     }
 
     @Test
+    public void verifyMqConfig() throws JMSException {
+        final MQSinkTask newConnectTask = new MQSinkTask();
+
+        // configure a sink task for string messages
+        final Map<String, String> connectorConfigProps = createDefaultConnectorProperties();
+        connectorConfigProps.put("mq.message.builder",
+                DEFAULT_MESSAGE_BUILDER);
+
+        connectorConfigProps.put("mq.ssl.use.ibm.cipher.mappings",
+                "true");        
+
+        // start the task so that it connects to MQ
+        newConnectTask.start(connectorConfigProps);
+
+        // create some test messages
+        final List<SinkRecord> records = new ArrayList<>();
+        records.add(generateSinkRecord(null, "hello"));
+        records.add(generateSinkRecord(null, "world"));
+        newConnectTask.put(records);
+
+        // flush the messages
+        final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        final TopicPartition topic = new TopicPartition(TOPIC, PARTITION);
+        final OffsetAndMetadata offset = new OffsetAndMetadata(commonOffset);
+        offsets.put(topic, offset);
+        newConnectTask.flush(offsets);
+
+        // stop the task
+        newConnectTask.stop();
+
+        // verify that the messages were successfully submitted to MQ
+        final List<Message> messagesInMQ = getAllMessagesFromQueue(DEFAULT_SINK_QUEUE_NAME);
+        assertEquals(2, messagesInMQ.size());
+        assertEquals("hello", messagesInMQ.get(0).getBody(String.class));
+        assertEquals("world", messagesInMQ.get(1).getBody(String.class));
+    }
+
+    @Test
     public void verifyStringJmsMessages() throws JMSException {
         final MQSinkTask newConnectTask = new MQSinkTask();
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/JMSWorker.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/JMSWorker.java
@@ -102,7 +102,7 @@ public class JMSWorker {
         mqConnectionHelper = new MQConnectionHelper(config);
 
         if (mqConnectionHelper.getUseIBMCipherMappings() != null) {
-            System.setProperty("com.ibm.mq.cfg.useIBMCipherMappings", mqConnectionHelper.getUseIBMCipherMappings());
+            System.setProperty("com.ibm.mq.cfg.useIBMCipherMappings", Boolean.toString(mqConnectionHelper.getUseIBMCipherMappings()));
         }
 
         try {

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/MQConnectionHelper.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/MQConnectionHelper.java
@@ -63,8 +63,8 @@ public class MQConnectionHelper {
         return config.getBoolean(MQSinkConfig.CONFIG_NAME_MQ_PERSISTENT);
     }
 
-    public String getUseIBMCipherMappings() {
-        return config.getString(MQSinkConfig.CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS);
+    public Boolean getUseIBMCipherMappings() {
+        return config.getBoolean(MQSinkConfig.CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS);
     }
 
     public int getTransportType() {


### PR DESCRIPTION
Signed-off-by: A S Adil Mohammad <asadilmohammad2020@gmail.com>

# Description

This  pull request fixes the issue of exception when setting mq.ssl.use.ibm.cipher.mappings.In source code, the configuration `CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS `is defined as Type.BOOLEAN but it was being used as: `config.getString(MQSinkConfig.CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS)`

Fixes #73 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Integration Test

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules