### PR TITLE
fix: upgrade bouncy castle dependency to address CVE-2025-8916

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.ibm.mq</groupId>
       <artifactId>com.ibm.mq.allclient</artifactId>
-      <version>9.4.0.5</version>
+      <version>9.4.4.1</version>
     </dependency>
 
     <dependency>

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/AbstractJMSContextIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/AbstractJMSContextIT.java
@@ -91,7 +91,7 @@ public abstract class AbstractJMSContextIT {
     public static final String CONNECTION_MODE = "client";
     public static final String HOST_NAME = "localhost";
 
-    public static final String MQ_IMAGE = "icr.io/ibm-messaging/mq:9.4.0.5-r2";
+    public static final String MQ_IMAGE = "icr.io/ibm-messaging/mq:9.4.4.1-r1";
     public static final boolean USER_AUTHENTICATION_MQCSP = false;
 
     protected final ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION

# Description
- Upgraded com.ibm.mq:com.ibm.mq.allclient from 9.4.0.5 to 9.4.4.1
- This resolves CVE-2025-8916 in org.bouncycastle:bcprov-jdk18on
- Bouncy Castle upgraded from 1.78.1 (vulnerable) to 1.81 (fixed)

# Fixes (https://github.com/ibm-messaging/kafka-connect-mq-sink/issues/79)

# Signed-off-by: Meenu Mariya [meenu.mariya@ibm.com](mailto:meenu.mariya@ibm.com)