### PR TITLE
Handle MQMD JMS headers which require proper type casting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>com.ibm.eventstreams.connect</groupId>
   <artifactId>kafka-connect-mq-sink</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.1</version>
+  <version>2.3.0</version>
   <name>kafka-connect-mq-sink</name>
   <organization>
     <name>IBM Corporation</name>
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.20.2</version>
+      <version>1.21.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQMDTests.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQMDTests.java
@@ -251,7 +251,7 @@ public class MQMDTests extends MQSinkTaskAuthIT {
      // Test that MQMD integer headers work correctly when set as String:
      // - Enable mq.message.mqmd.write=true
      // - Enable mq.kafka.headers.copy.to.jms.properties=true
-     // - Send a message with JMS_IBM_MQMD_Priority as a String (simulating Source Connector behavior)
+     // - Send a message with JMS_IBM_MQMD_Priority as a String 
      // - Should succeed (converts String to Integer automatically)
 
         // Grant MQMD context permissions to the app user (required for mq.message.mqmd.write=true)
@@ -462,7 +462,7 @@ public class MQMDTests extends MQSinkTaskAuthIT {
         // Test that all MQMD headers work correctly:
         // - Enable mq.message.mqmd.write=true
         // - Enable mq.kafka.headers.copy.to.jms.properties=true
-        // - Send a message with all MQMD headers as Strings (as they come from previous versions of MQ Source Connector)
+        // - Send a message with all MQMD headers as Strings 
         // - Should succeed with automatic type conversion
 
         // Grant MQMD context permissions to the app user
@@ -566,5 +566,4 @@ public class MQMDTests extends MQSinkTaskAuthIT {
         final MQMessage[] messagesInMQ = mqGet(AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME);
         assertEquals(1, messagesInMQ.length);
     }
-
 }

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQMDTests.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQMDTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 IBM Corporation
+ * Copyright 2024, 2026 IBM Corporation
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.Test;
@@ -128,7 +129,7 @@ public class MQMDTests extends MQSinkTaskAuthIT {
         // considered a retriable exception, the system retries it, leading to
         // RetriableException
         assertThrows(RetriableException.class, () -> {
-            newConnectTask.put(records);
+                newConnectTask.put(records);
         });
     }
 
@@ -244,4 +245,326 @@ public class MQMDTests extends MQSinkTaskAuthIT {
         assertEquals("ThisIsMyPutApplicationName", messagesInMQ[0].putApplicationName.trim());
         assertEquals("MYQMGR", messagesInMQ[0].replyToQueueManagerName.trim());
     }
+
+    @Test
+    public void testMQMDIntegerHeaderWorksWhenSetAsString() throws Exception {
+     // Test that MQMD integer headers work correctly when set as String:
+     // - Enable mq.message.mqmd.write=true
+     // - Enable mq.kafka.headers.copy.to.jms.properties=true
+     // - Send a message with JMS_IBM_MQMD_Priority as a String (simulating Source Connector behavior)
+     // - Should succeed (converts String to Integer automatically)
+
+        // Grant MQMD context permissions to the app user (required for mq.message.mqmd.write=true)
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-n", AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "queue",
+                "+setall", "+get", "+browse", "+put", "+inq");
+
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "qmgr",
+                "+setall");
+
+        // Create connector configuration with both MQMD write and header copy enabled
+        final Map<String, String> connectorProps = createDefaultConnectorProperties();
+        connectorProps.put("mq.message.builder", AbstractJMSContextIT.DEFAULT_MESSAGE_BUILDER);
+
+        // Enable header copying (customer's configuration)
+        connectorProps.put("mq.kafka.headers.copy.to.jms.properties", "true");
+
+        // Create and start the sink task
+        final MQSinkTask task = new MQSinkTask();
+        task.initialize(mock(SinkTaskContext.class));
+        task.start(connectorProps);
+
+        try {
+            // Create a SinkRecord with JMS_IBM_MQMD_Priority as a String
+            final ConnectHeaders headers = new ConnectHeaders();
+            headers.addString("JMS_IBM_MQMD_Priority", "5");  // Source stores as String, not Integer!
+
+            final SinkRecord record = new SinkRecord(
+                    AbstractJMSContextIT.TOPIC,
+                    AbstractJMSContextIT.PARTITION,
+                    Schema.STRING_SCHEMA,
+                    "key",
+                    Schema.STRING_SCHEMA,
+                    "Test message for integer MQMD headers when set as string",
+                    0,
+                    null,
+                    null,
+                    headers
+            );
+
+            final List<SinkRecord> records = new ArrayList<>();
+            records.add(record);
+
+            //The connector automatically converts the String "5"
+            // to Integer 5 when setting JMS_IBM_MQMD_Priority
+
+            task.put(records);
+
+            // Flush the message
+            final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+            final TopicPartition topic = new TopicPartition(AbstractJMSContextIT.TOPIC, AbstractJMSContextIT.PARTITION);
+            final OffsetAndMetadata offset = new OffsetAndMetadata(0L);
+            offsets.put(topic, offset);
+            task.flush(offsets);
+
+        } finally {
+            task.stop();
+        }
+
+        // Clean up: consume the message from the queue to avoid polluting other tests
+        final MQMessage[] messagesInMQ = mqGet(AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME);
+        assertEquals(1, messagesInMQ.length);
+    }
+
+
+    @Test
+    public void testMQMDStringHeaderWorks() throws Exception {
+        // Grant MQMD context permissions to the app user
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-n", AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "queue",
+                "+setall", "+get", "+browse", "+put", "+inq");
+
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "qmgr",
+                "+setall");
+
+        final Map<String, String> connectorProps = createDefaultConnectorProperties();
+        connectorProps.put("mq.message.builder", AbstractJMSContextIT.DEFAULT_MESSAGE_BUILDER);
+        connectorProps.put("mq.kafka.headers.copy.to.jms.properties", "true");
+
+        final MQSinkTask task = new MQSinkTask();
+        task.initialize(mock(SinkTaskContext.class));
+        task.start(connectorProps);
+
+        try {
+            // String MQMD properties should work fine
+            final ConnectHeaders headers = new ConnectHeaders();
+            headers.addString("JMS_IBM_MQMD_Format", "MQSTR");
+            headers.addString("JMS_IBM_MQMD_ReplyToQ", "REPLY.QUEUE");
+
+            final SinkRecord record = new SinkRecord(
+                    AbstractJMSContextIT.TOPIC,
+                    AbstractJMSContextIT.PARTITION,
+                    Schema.STRING_SCHEMA,
+                    "key",
+                    Schema.STRING_SCHEMA,
+                    "Test message with string MQMD headers",
+                    0,
+                    null,
+                    null,
+                    headers
+            );
+
+            final List<SinkRecord> records = new ArrayList<>();
+            records.add(record);
+
+            task.put(records);
+
+            // Flush the message
+            final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+            final TopicPartition topic = new TopicPartition(AbstractJMSContextIT.TOPIC, AbstractJMSContextIT.PARTITION);
+            final OffsetAndMetadata offset = new OffsetAndMetadata(0L);
+            offsets.put(topic, offset);
+            task.flush(offsets);
+
+        } finally {
+            task.stop();
+        }
+
+        // Clean up: consume the message from the queue to avoid polluting other tests
+        final MQMessage[] messagesInMQ = mqGet(AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME);
+        assertEquals(1, messagesInMQ.length);
+    }
+
+    @Test
+    public void testMQMDWithoutHeadersWorks() throws Exception {
+        // Test that messages work correctly when MQMD headers are not provided:
+        // - Enable mq.message.mqmd.write=true
+        // - Enable mq.kafka.headers.copy.to.jms.properties=true
+        // - Send a message WITHOUT any JMS_IBM_MQMD_* headers
+        // - Should succeed (no headers to copy, uses defaults)
+
+        // Grant MQMD context permissions to the app user
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-n", AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "queue",
+                "+setall", "+get", "+browse", "+put", "+inq");
+
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "qmgr",
+                "+setall");
+
+        final Map<String, String> connectorProps = createDefaultConnectorProperties();
+        connectorProps.put("mq.message.builder", AbstractJMSContextIT.DEFAULT_MESSAGE_BUILDER);
+        connectorProps.put("mq.kafka.headers.copy.to.jms.properties", "true");
+
+        final MQSinkTask task = new MQSinkTask();
+        task.initialize(mock(SinkTaskContext.class));
+        task.start(connectorProps);
+
+        try {
+            // Create a message with NO MQMD headers at all
+            final ConnectHeaders headers = new ConnectHeaders();
+            // Intentionally not adding any JMS_IBM_MQMD_* headers
+
+            final SinkRecord record = new SinkRecord(
+                    AbstractJMSContextIT.TOPIC,
+                    AbstractJMSContextIT.PARTITION,
+                    Schema.STRING_SCHEMA,
+                    "key",
+                    Schema.STRING_SCHEMA,
+                    "Test message without MQMD headers",
+                    0,
+                    null,
+                    null,
+                    headers
+            );
+
+            final List<SinkRecord> records = new ArrayList<>();
+            records.add(record);
+
+            // This should succeed - no MQMD headers to process, uses MQ defaults
+            task.put(records);
+
+            // Flush the message
+            final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+            final TopicPartition topic = new TopicPartition(AbstractJMSContextIT.TOPIC, AbstractJMSContextIT.PARTITION);
+            final OffsetAndMetadata offset = new OffsetAndMetadata(0L);
+            offsets.put(topic, offset);
+            task.flush(offsets);
+
+        } finally {
+            task.stop();
+        }
+
+        // Clean up: consume the message from the queue to avoid polluting other tests
+        final MQMessage[] messagesInMQ = mqGet(AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME);
+        assertEquals(1, messagesInMQ.length);
+    }
+
+    @Test
+    public void testAllMQMDHeadersWork() throws Exception {
+        // Test that all MQMD headers work correctly:
+        // - Enable mq.message.mqmd.write=true
+        // - Enable mq.kafka.headers.copy.to.jms.properties=true
+        // - Send a message with all MQMD headers as Strings (as they come from previous versions of MQ Source Connector)
+        // - Should succeed with automatic type conversion
+
+        // Grant MQMD context permissions to the app user
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-n", AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "queue",
+                "+setall", "+get", "+browse", "+put", "+inq");
+
+        MQ_CONTAINER.execInContainer("setmqaut",
+                "-m", AbstractJMSContextIT.QMGR_NAME,
+                "-p", AbstractJMSContextIT.APP_USERNAME,
+                "-t", "qmgr",
+                "+setall");
+
+        final Map<String, String> connectorProps = createDefaultConnectorProperties();
+        connectorProps.put("mq.message.builder", AbstractJMSContextIT.DEFAULT_MESSAGE_BUILDER);
+        connectorProps.put("mq.kafka.headers.copy.to.jms.properties", "true");
+
+        final MQSinkTask task = new MQSinkTask();
+        task.initialize(mock(SinkTaskContext.class));
+        task.start(connectorProps);
+
+        try {
+            // Create headers with all MQMD fields as Strings (simulating MQ Source Connector output)
+            final ConnectHeaders headers = new ConnectHeaders();
+
+            // Integer fields (will be converted from String to Integer)
+            headers.addString("JMS_IBM_MQMD_Priority", "2");
+            headers.addString("JMS_IBM_MQMD_CodedCharSetId", "437");
+            headers.addString("JMS_IBM_Encoding", "546");
+            headers.addString("JMS_IBM_MQMD_PutTime", "10214957");
+            headers.addString("JMS_IBM_MQMD_Expiry", "-1");
+            headers.addString("JMS_IBM_MQMD_MsgSeqNumber", "1");
+            headers.addString("JMS_IBM_PutApplType", "11");
+            headers.addString("JMS_IBM_MQMD_MsgFlags", "0");
+            headers.addString("JMSXDeliveryCount", "1");
+            headers.addString("JMS_IBM_MQMD_Offset", "0");
+            headers.addString("JMS_IBM_MsgType", "1");
+            headers.addString("JMS_IBM_MQMD_Report", "0");
+            headers.addString("JMS_IBM_MQMD_PutApplType", "11");
+            headers.addString("JMS_IBM_MQMD_Feedback", "0");
+            headers.addString("JMS_IBM_MQMD_Persistence", "0");
+            headers.addString("JMS_IBM_MQMD_BackoutCount", "0");
+            headers.addString("JMS_IBM_MQMD_MsgType", "1");
+            headers.addString("JMS_IBM_MQMD_Encoding", "546");
+            headers.addString("JMS_IBM_MQMD_OriginalLength", "-1");
+
+            // String fields (no conversion needed)
+            headers.addString("JMS_IBM_Character_Set", "IBM437");
+            headers.addString("JMS_IBM_MQMD_PutApplName", "test.exe");
+            headers.addString("JMS_IBM_Format", "MQSTR");
+            headers.addString("JMS_IBM_MQMD_UserIdentifier", "aumqemcgdsa");
+            headers.addString("JMS_IBM_MQMD_ApplOriginData", "data");
+            headers.addString("JMS_IBM_PutTime", "10214957");
+            headers.addString("JMS_IBM_MQMD_PutDate", "20260521");
+            headers.addString("JMSXUserID", "aumqemcgdsa");
+            headers.addString("JMS_IBM_MQMD_Format", "MQSTR");
+            headers.addString("JMS_IBM_MQMD_ReplyToQMgr", "AU3CGS1.MQ");
+            headers.addString("JMSXAppID", "test");
+            headers.addString("JMS_IBM_PutDate", "20260521");
+            headers.addString("JMS_IBM_MQMD_ApplIdentityData", "data");
+            headers.addString("JMS_IBM_MQMD_ReplyToQ", "test");
+
+
+            final SinkRecord record = new SinkRecord(
+                    AbstractJMSContextIT.TOPIC,
+                    AbstractJMSContextIT.PARTITION,
+                    Schema.STRING_SCHEMA,
+                    "key",
+                    Schema.STRING_SCHEMA,
+                    "Test message with all MQMD headers",
+                    0,
+                    null,
+                    null,
+                    headers
+            );
+
+            final List<SinkRecord> records = new ArrayList<>();
+            records.add(record);
+
+            // This should succeed - the connector handles all header types correctly
+            // Integer fields are converted from String to Integer
+            // String fields are passed through
+            // Byte array fields are handled appropriately
+            task.put(records);
+
+            // Flush the message
+            final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+            final TopicPartition topic = new TopicPartition(AbstractJMSContextIT.TOPIC, AbstractJMSContextIT.PARTITION);
+            final OffsetAndMetadata offset = new OffsetAndMetadata(0L);
+            offsets.put(topic, offset);
+            task.flush(offsets);
+
+        } finally {
+            task.stop();
+        }
+
+        // Clean up: consume the message from the queue to avoid polluting other tests
+        final MQMessage[] messagesInMQ = mqGet(AbstractJMSContextIT.DEFAULT_SINK_QUEUE_NAME);
+        assertEquals(1, messagesInMQ.length);
+    }
+
 }

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, 2023, 2024 IBM Corporation
+ * Copyright 2022, 2023, 2024, 2026 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,13 @@ package com.ibm.eventstreams.connect.mqsink.builders;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.jms.BytesMessage;
 import javax.jms.Message;
@@ -140,6 +144,99 @@ public class DefaultMessageBuilderIT extends AbstractJMSContextIT {
 
         // no message properties should be set by default
         assertFalse(message.getPropertyNames().hasMoreElements());
+    }
+
+    @Test
+    public void buildMessageWithMQMDByteArrayProperties() throws Exception {
+        // Test MQMD byte[] properties with mq.message.mqmd.write=true
+        // These properties can be set via setObjectProperty() when mqmd.write is enabled
+
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // MQMD byte[] properties - these are the 4 byte[] MQMD fields
+        final byte[] groupId = new byte[] {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+                                           0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
+                                           0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58};
+        final byte[] accountingToken = new byte[] {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+                                                    0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70,
+                                                    0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+                                                    0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F, (byte)0x80};
+
+        headers.addBytes("JMS_IBM_MQMD_GroupId", groupId);
+        headers.addBytes("JMS_IBM_MQMD_AccountingToken", accountingToken);
+
+        // generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify each MQMD byte[] property can be retrieved
+        // Note: We can't directly verify the byte[] values in integration tests without accessing
+        // the underlying MQ message, but we can verify the message was created successfully
+        // and the properties were set (they would throw an exception if they couldn't be set)
+        assertNotNull(message);
+
+        // Verify the properties exist (propertyExists returns true if set, even for byte[])
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_GroupId"));
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_AccountingToken"));
+    }
+
+    @Test
+    public void buildMessageWithMQMDByteArrayPropertiesFromBase64() throws Exception {
+        // Test MQMD byte[] properties using Base64 encoded strings
+        // This demonstrates that users can provide byte[] values as Base64 strings
+
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // Base64 encoded values for MQMD byte[] properties
+        // GroupId: 24 bytes - "QUJDREVGR0hJSktMTU5PUFFSU1RVVlc=" decodes to bytes 0x41-0x58
+        final String groupIdBase64 = "QUJDREVGR0hJSktMTU5PUFFSU1RVVlc=";
+
+        // AccountingToken: 32 bytes - "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4A=" decodes to bytes 0x61-0x80
+        final String accountingTokenBase64 = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4A=";
+
+        // Add as String headers - the converter will decode them to byte[]
+        headers.addString("JMS_IBM_MQMD_GroupId", groupIdBase64);
+        headers.addString("JMS_IBM_MQMD_AccountingToken", accountingTokenBase64);
+
+        // generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify the message was created successfully
+        assertNotNull(message);
+
+        // Verify the properties exist (they were decoded from Base64 and set as byte[])
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_GroupId"));
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_AccountingToken"));
+    }
+
+    private SinkRecord generateSinkRecord(final ConnectHeaders headers) {
+        final String topic = "TOPIC.NAME";
+        final int partition = 0;
+        final long offset = 0;
+        final Schema keySchema = Schema.STRING_SCHEMA;
+        final String key = "mykey";
+        final Schema valueSchema = Schema.STRING_SCHEMA;
+        final String value = "Test message";
+
+        return new SinkRecord(topic, partition,
+                keySchema, key,
+                valueSchema, value,
+                offset,
+                null, TimestampType.NO_TIMESTAMP_TYPE,
+                headers);
     }
 
     private void createAndVerifyEmptyMessage(final Schema valueSchema) throws Exception {

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderWithHeadersIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/DefaultMessageBuilderWithHeadersIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, 2023, 2024 IBM Corporation
+ * Copyright 2023, 2023, 2024, 2026 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.ibm.eventstreams.connect.mqsink.builders;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -139,5 +140,579 @@ public class DefaultMessageBuilderWithHeadersIT extends AbstractJMSContextIT {
         // verify MQ message properties
         assertEquals("3.14159265359", message.getStringProperty("TestPi"));
         assertEquals(3.14159265359, message.getDoubleProperty("TestPi"), 0.0000000001);
+    }
+
+    @Test
+    public void buildMessageWithMQMDIntegerProperties() throws Exception {
+        // Test MQMD Integer properties according to IBM MQ documentation:
+        // https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=application-jms-message-object-properties
+
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // Priority property - Integer (0-9)
+        headers.addString("JMS_IBM_MQMD_Priority", "5");
+
+        // Expiry property - Integer (time-to-live in tenths of a second, or MQEXPIRY_DEFAULT, MQEXPIRY_UNLIMITED)
+        headers.addString("JMS_IBM_MQMD_Expiry", "36000"); // 1 hour in tenths of a second
+
+        // MsgType property - Integer
+        headers.addString("JMS_IBM_MQMD_MsgType", "1"); // MQMT_REQUEST
+
+        // Report property - Integer (report options)
+        headers.addString("JMS_IBM_MQMD_Report", "0");
+
+        // Encoding property - Integer (numeric encoding)
+        headers.addString("JMS_IBM_MQMD_Encoding", "546"); // MQENC_NATIVE
+
+        // CodedCharSetId property - Integer (character set)
+        headers.addString("JMS_IBM_MQMD_CodedCharSetId", "819"); // UTF-8
+
+        // Persistence property - Integer (MQPER_PERSISTENT, MQPER_NOT_PERSISTENT)
+        headers.addString("JMS_IBM_MQMD_Persistence", "1"); // MQPER_PERSISTENT
+
+        // Feedback property - Integer (feedback code)
+        headers.addString("JMS_IBM_MQMD_Feedback", "0");
+
+        // PutApplType property - Integer (application type)
+        headers.addString("JMS_IBM_MQMD_PutApplType", "11"); // MQAT_WINDOWS
+
+        // MsgSeqNumber property - Integer
+        headers.addString("JMS_IBM_MQMD_MsgSeqNumber", "1");
+
+        // Offset property - Integer
+        headers.addString("JMS_IBM_MQMD_Offset", "0");
+
+        // MsgFlags property - Integer
+        headers.addString("JMS_IBM_MQMD_MsgFlags", "0");
+
+        // OriginalLength property - Integer
+        headers.addString("JMS_IBM_MQMD_OriginalLength", "-1"); // MQOL_UNDEFINED
+
+        // generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify each MQMD integer property can be retrieved with correct type
+        assertEquals(5, message.getIntProperty("JMS_IBM_MQMD_Priority"));
+        assertEquals(36000, message.getIntProperty("JMS_IBM_MQMD_Expiry"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_MQMD_MsgType"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_MQMD_Report"));
+        assertEquals(546, message.getIntProperty("JMS_IBM_MQMD_Encoding"));
+        assertEquals(819, message.getIntProperty("JMS_IBM_MQMD_CodedCharSetId"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_MQMD_Persistence"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_MQMD_Feedback"));
+        assertEquals(11, message.getIntProperty("JMS_IBM_MQMD_PutApplType"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_MQMD_MsgSeqNumber"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_MQMD_Offset"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_MQMD_MsgFlags"));
+        assertEquals(-1, message.getIntProperty("JMS_IBM_MQMD_OriginalLength"));
+    }
+
+    @Test
+    public void buildMessageWithMQMDIntegerPropertiesAsStrings() throws Exception {
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        headers.addString("JMS_IBM_MQMD_Priority", "5");
+        headers.addString("JMS_IBM_MQMD_Expiry", "36000");
+        headers.addString("JMS_IBM_MQMD_MsgType", "1");
+        headers.addString("JMS_IBM_MQMD_Encoding", "546");
+        headers.addString("JMS_IBM_MQMD_CodedCharSetId", "819");
+        headers.addString("JMS_IBM_MQMD_Persistence", "1");
+        headers.addString("JMS_IBM_MQMD_Feedback", "0");
+        headers.addString("JMS_IBM_MQMD_PutApplType", "11");
+        headers.addString("JMS_IBM_MQMD_MsgSeqNumber", "1");
+        headers.addString("JMS_IBM_MQMD_Offset", "0");
+        headers.addString("JMS_IBM_MQMD_MsgFlags", "0");
+        headers.addString("JMS_IBM_MQMD_OriginalLength", "-1");
+
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        assertEquals(5, message.getIntProperty("JMS_IBM_MQMD_Priority"));
+        assertEquals(36000, message.getIntProperty("JMS_IBM_MQMD_Expiry"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_MQMD_MsgType"));
+        assertEquals(546, message.getIntProperty("JMS_IBM_MQMD_Encoding"));
+        assertEquals(819, message.getIntProperty("JMS_IBM_MQMD_CodedCharSetId"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_MQMD_Persistence"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_MQMD_Feedback"));
+        assertEquals(11, message.getIntProperty("JMS_IBM_MQMD_PutApplType"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_MQMD_MsgSeqNumber"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_MQMD_Offset"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_MQMD_MsgFlags"));
+        assertEquals(-1, message.getIntProperty("JMS_IBM_MQMD_OriginalLength"));
+    }
+
+    @Test
+    public void buildMessageWithInvalidMQMDIntegerPropertyAsStringIsSkipped() throws Exception {
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("JMS_IBM_MQMD_Priority", "abc");  // Invalid integer value
+        headers.addString("JMS_IBM_MQMD_CodedCharSetId", "819");  // Valid integer
+
+        // Message should be created successfully, invalid property is skipped
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Valid property should be set
+        assertEquals(819, message.getIntProperty("JMS_IBM_MQMD_CodedCharSetId"));
+
+        // Invalid property should be skipped (not set)
+        assertFalse(message.propertyExists("JMS_IBM_MQMD_Priority"));
+    }
+
+    @Test
+    public void buildMessageWithInvalidMQMDIntegerPropertyAsFloatStringIsSkipped() throws Exception {
+        // Test that a float string like "5.0" for an Integer MQMD property is skipped
+        // This validates that invalid values don't cause message processing to fail
+
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+        // Try to set Priority with a float string - this should be skipped
+        headers.addString("JMS_IBM_MQMD_Priority", "5.0");
+        // Add a valid property to ensure message is still created
+        headers.addString("JMS_IBM_MQMD_Format", "MQSTR");
+
+        // Message should be created successfully, invalid property is skipped
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Valid property should be set
+        assertEquals("MQSTR", message.getStringProperty("JMS_IBM_MQMD_Format"));
+
+        // Invalid property should NOT be set (skipped due to NumberFormatException)
+        assertFalse(message.propertyExists("JMS_IBM_MQMD_Priority"));
+    }
+
+    @Test
+    public void buildMessageWithMQMDStringProperties() throws Exception {
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        headers.addString("JMS_IBM_MQMD_Format", "MQSTR");
+        headers.addString("JMS_IBM_MQMD_ReplyToQ", "REPLY.QUEUE");
+        headers.addString("JMS_IBM_MQMD_ReplyToQMgr", "REPLY.QMGR");
+        headers.addString("JMS_IBM_MQMD_UserIdentifier", "testuser");
+        headers.addString("JMS_IBM_MQMD_ApplIdentityData", "ApplicationID123");
+        headers.addString("JMS_IBM_MQMD_PutApplName", "TestApplication");
+        headers.addString("JMS_IBM_MQMD_PutDate", "20240129");
+        headers.addString("JMS_IBM_MQMD_PutTime", "14302156");
+        headers.addString("JMS_IBM_MQMD_ApplOriginData", "OriginData");
+
+        // generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify each MQMD string property can be retrieved with correct type
+        assertEquals("MQSTR", message.getStringProperty("JMS_IBM_MQMD_Format"));
+        assertEquals("REPLY.QUEUE", message.getStringProperty("JMS_IBM_MQMD_ReplyToQ"));
+        assertEquals("REPLY.QMGR", message.getStringProperty("JMS_IBM_MQMD_ReplyToQMgr"));
+        assertEquals("testuser", message.getStringProperty("JMS_IBM_MQMD_UserIdentifier"));
+        assertEquals("ApplicationID123", message.getStringProperty("JMS_IBM_MQMD_ApplIdentityData"));
+        assertEquals("TestApplication", message.getStringProperty("JMS_IBM_MQMD_PutApplName"));
+        assertEquals("20240129", message.getStringProperty("JMS_IBM_MQMD_PutDate"));
+        assertEquals("14302156", message.getStringProperty("JMS_IBM_MQMD_PutTime"));
+        assertEquals("OriginData", message.getStringProperty("JMS_IBM_MQMD_ApplOriginData"));
+    }
+
+    @Test
+    public void buildMessageWithMixedTypeHeaders() throws Exception {
+        // Comprehensive test with all supported numeric JMS property types
+        // to ensure type preservation when copying Kafka headers to JMS properties
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // Add various typed headers
+        headers.addString("StringProp", "test_value");
+        headers.addInt("IntProp", 42);
+        headers.addLong("LongProp", 1234567890L);
+        headers.addBoolean("BoolProp", true);
+        headers.addDouble("DoubleProp", 3.14159);
+        headers.addFloat("FloatProp", 2.71828f);
+        headers.addByte("ByteProp", (byte) 127);
+        headers.addShort("ShortProp", (short) 32000);
+
+        // generate MQ message
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify each property can be retrieved with its correct type
+        assertEquals("test_value", message.getStringProperty("StringProp"));
+        assertEquals(42, message.getIntProperty("IntProp"));
+        assertEquals(1234567890L, message.getLongProperty("LongProp"));
+        assertEquals(true, message.getBooleanProperty("BoolProp"));
+        assertEquals(3.14159, message.getDoubleProperty("DoubleProp"), 0.0001);
+        assertEquals(2.71828f, message.getFloatProperty("FloatProp"), 0.0001f);
+        assertEquals((byte) 127, message.getByteProperty("ByteProp"));
+        assertEquals((short) 32000, message.getShortProperty("ShortProp"));
+    }
+
+    @Test
+    public void buildMessageWithJMSIBMIntegerProperties() throws Exception {
+        // Test JMS_IBM Integer properties (non-MQMD) according to IBM MQ documentation:
+        // https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=messages-jms-fields-properties-corresponding-mqmd-fields
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // Report options - Integer values
+        headers.addString("JMS_IBM_Report_Exception", "1");
+        headers.addString("JMS_IBM_Report_Expiration", "1");
+        headers.addString("JMS_IBM_Report_COA", "1");
+        headers.addString("JMS_IBM_Report_COD", "1");
+        headers.addString("JMS_IBM_Report_PAN", "0");
+        headers.addString("JMS_IBM_Report_NAN", "0");
+        headers.addString("JMS_IBM_Report_Pass_Msg_ID", "1");
+        headers.addString("JMS_IBM_Report_Pass_Correl_ID", "1");
+        headers.addString("JMS_IBM_Report_Discard_Msg", "0");
+
+        // Message type - Integer
+        headers.addString("JMS_IBM_MsgType", "8"); // MQMT_DATAGRAM
+
+        // Feedback - Integer
+        headers.addString("JMS_IBM_Feedback", "0");
+
+        // Encoding - Integer (numeric encoding)
+        headers.addString("JMS_IBM_Encoding", "546"); // MQENC_NATIVE
+
+        // Character Set - Integer
+        headers.addString("JMS_IBM_Character_Set", "819"); // UTF-8
+
+        // Put Application Type - Integer
+        headers.addString("JMS_IBM_PutApplType", "11"); // MQAT_WINDOWS
+
+        // generate MQ message
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify each JMS_IBM integer property can be retrieved with correct type
+        assertEquals(1, message.getIntProperty("JMS_IBM_Report_Exception"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_Report_Expiration"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_Report_COA"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_Report_COD"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_Report_PAN"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_Report_NAN"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_Report_Pass_Msg_ID"));
+        assertEquals(1, message.getIntProperty("JMS_IBM_Report_Pass_Correl_ID"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_Report_Discard_Msg"));
+        assertEquals(8, message.getIntProperty("JMS_IBM_MsgType"));
+        assertEquals(0, message.getIntProperty("JMS_IBM_Feedback"));
+        assertEquals(546, message.getIntProperty("JMS_IBM_Encoding"));
+        assertEquals(819, message.getIntProperty("JMS_IBM_Character_Set"));
+        assertEquals(11, message.getIntProperty("JMS_IBM_PutApplType"));
+    }
+
+    @Test
+    public void buildMessageWithJMSIBMBooleanProperties() throws Exception {
+        // Test JMS_IBM Boolean properties (non-MQMD) according to IBM MQ documentation:
+        // JMS_IBM_Last_Msg_In_Group requires Boolean type
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // Last message in group - Boolean
+        headers.addString("JMS_IBM_Last_Msg_In_Group", "true");
+
+        // generate MQ message
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify JMS_IBM boolean property can be retrieved with correct type
+        assertEquals(true, message.getBooleanProperty("JMS_IBM_Last_Msg_In_Group"));
+    }
+
+    @Test
+    public void buildMessageWithJMSIBMBooleanPropertyAsInteger() throws Exception {
+        final ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("JMS_IBM_Last_Msg_In_Group", "1");
+
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+        assertEquals(true, message.getBooleanProperty("JMS_IBM_Last_Msg_In_Group"));
+    }
+
+    @Test
+    public void buildMessageWithJMSIBMBooleanPropertyAsStringTrue() throws Exception {
+        final ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("JMS_IBM_Last_Msg_In_Group", "true");
+
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+        assertEquals(true, message.getBooleanProperty("JMS_IBM_Last_Msg_In_Group"));
+    }
+
+    @Test
+    public void buildMessageWithJMSIBMBooleanPropertyAsStringFalse() throws Exception {
+        final ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("JMS_IBM_Last_Msg_In_Group", "false");
+
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+        assertEquals(false, message.getBooleanProperty("JMS_IBM_Last_Msg_In_Group"));
+    }
+
+    @Test
+    public void buildMessageWithJMSIBMStringProperties() throws Exception {
+        // Test JMS_IBM String properties (non-MQMD) according to IBM MQ documentation:
+        // The following JMS_IBM properties require String type and can be set:
+        // - JMS_IBM_Format (String)
+        //
+        // Note: JMS_IBM_PutAppl, JMS_IBM_PutDate, JMS_IBM_PutTime are read-only
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        headers.addString("JMS_IBM_Format", "MQSTR");
+
+        // generate MQ message
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify JMS_IBM string property can be retrieved with correct type
+        assertEquals("MQSTR", message.getStringProperty("JMS_IBM_Format"));
+    }
+
+    @Test
+    public void buildMessageWithMixedMQMDAndJMSIBMProperties() throws Exception {
+        // Comprehensive test with both MQMD and JMS_IBM properties
+        // to ensure all IBM MQ property types are handled correctly
+
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // MQMD Integer properties
+        headers.addString("JMS_IBM_MQMD_Priority", "5");
+        headers.addString("JMS_IBM_MQMD_Expiry", "36000");
+        headers.addString("JMS_IBM_MQMD_Encoding", "546");
+
+        // MQMD String properties
+        headers.addString("JMS_IBM_MQMD_Format", "MQSTR");
+        headers.addString("JMS_IBM_MQMD_ReplyToQ", "REPLY.QUEUE");
+
+
+        // JMS_IBM Integer properties
+        headers.addString("JMS_IBM_Encoding", "546");
+        headers.addString("JMS_IBM_Character_Set", "819");
+        headers.addString("JMS_IBM_MsgType", "8");
+
+        // JMS_IBM String properties
+        headers.addString("JMS_IBM_Format", "MQSTR");
+
+        // JMS_IBM Boolean properties
+        headers.addString("JMS_IBM_Last_Msg_In_Group", "true");
+
+        // Regular properties (should be converted to strings)
+        headers.addString("CustomStringProp", "custom_value");
+        headers.addString("CustomIntProp", "999");
+
+        // generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify MQMD properties
+        assertEquals(5, message.getIntProperty("JMS_IBM_MQMD_Priority"));
+        assertEquals(36000, message.getIntProperty("JMS_IBM_MQMD_Expiry"));
+        assertEquals(546, message.getIntProperty("JMS_IBM_MQMD_Encoding"));
+        assertEquals("MQSTR", message.getStringProperty("JMS_IBM_MQMD_Format"));
+        assertEquals("REPLY.QUEUE", message.getStringProperty("JMS_IBM_MQMD_ReplyToQ"));
+
+        // Verify JMS_IBM properties
+        assertEquals(546, message.getIntProperty("JMS_IBM_Encoding"));
+        assertEquals(819, message.getIntProperty("JMS_IBM_Character_Set"));
+        assertEquals(8, message.getIntProperty("JMS_IBM_MsgType"));
+        assertEquals("MQSTR", message.getStringProperty("JMS_IBM_Format"));
+        assertEquals(true, message.getBooleanProperty("JMS_IBM_Last_Msg_In_Group"));
+
+        // Verify regular properties (converted to strings)
+        assertEquals("custom_value", message.getStringProperty("CustomStringProp"));
+        assertEquals("999", message.getStringProperty("CustomIntProp"));
+    }
+
+    @Test
+    public void buildMessageWithMQMDByteArrayProperties() throws Exception {
+        // Test MQMD byte[] properties with mq.message.mqmd.write=true
+        // These properties can be set via setObjectProperty() when mqmd.write is enabled
+
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // MQMD byte[] properties - these are the 4 byte[] MQMD fields
+        final byte[] groupId = new byte[] {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+                                           0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
+                                           0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58};
+        final byte[] accountingToken = new byte[] {0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+                                                    0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70,
+                                                    0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+                                                    0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F, (byte)0x80};
+
+        headers.addString("JMS_IBM_MQMD_GroupId", java.util.Base64.getEncoder().encodeToString(groupId));
+        headers.addString("JMS_IBM_MQMD_AccountingToken", java.util.Base64.getEncoder().encodeToString(accountingToken));
+
+        // generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify each MQMD byte[] property can be retrieved
+        // Note: We can't directly verify the byte[] values in integration tests without accessing
+        // the underlying MQ message, but we can verify the message was created successfully
+        // and the properties were set (they would throw an exception if they couldn't be set)
+        assertNotNull(message);
+
+        // Verify the properties exist (propertyExists returns true if set, even for byte[])
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_GroupId"));
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_AccountingToken"));
+    }
+
+    @Test
+    public void buildMessageWithMQMDByteArrayPropertiesSkippedWhenDisabled() throws Exception {
+        // Test that MQMD byte[] properties are skipped when mq.message.mqmd.write=false
+        // Uses the default builder which has mqmd.write disabled
+        // Note: The actual code expects Base64-encoded strings for byte array properties
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // MQMD byte[] properties as Base64-encoded strings (matching actual code behavior)
+        final byte[] msgId = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                                         0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+                                         0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18};
+        final byte[] correlId = new byte[] {0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+                                            0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
+                                            0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38};
+
+        // Add as Base64-encoded strings (how the source connector sends them)
+        headers.addBytes("JMS_IBM_MQMD_MsgId", msgId);
+        headers.addBytes("JMS_IBM_MQMD_CorrelId", correlId);
+
+        // generate MQ message - should succeed but properties should be skipped
+        final Message message = builder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify message was created successfully
+        assertNotNull(message);
+
+        // Verify the MQMD byte[] properties were NOT set (skipped because mqmd.write=false)
+        assertFalse(message.propertyExists("JMS_IBM_MQMD_MsgId"));
+        assertFalse(message.propertyExists("JMS_IBM_MQMD_CorrelId"));
+    }
+
+    @Test
+    public void buildMessageSkipsJmsMqmdBackoutCount() throws Exception {
+        // Test that JMS_IBM_MQMD_BackoutCount is NOT set even when it is present
+        // Create builder with mq.message.mqmd.write=true to ensure other MQMD properties work
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // Add JMS_IBM_MQMD_BackoutCount - this should be skipped
+        headers.addString("JMS_IBM_MQMD_BackoutCount", "5");
+
+        // Add another MQMD property to verify mqmd.write is working
+        headers.addString("JMS_IBM_MQMD_Priority", "7");
+
+        // Generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify JMS_IBM_MQMD_BackoutCount was NOT set (connector skips it)
+        assertFalse(message.propertyExists("JMS_IBM_MQMD_BackoutCount"));
+
+        // Verify other MQMD property WAS set (to confirm mqmd.write is working)
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_Priority"));
+        assertEquals(7, message.getIntProperty("JMS_IBM_MQMD_Priority"));
+    }
+
+    @Test
+    public void buildMessageWithHeadersFromNewSourceConnector() throws Exception {
+        // Test the actual flow: New source connector sends everything as String (except byte[])
+        // This validates the sink can correctly parse String headers back to proper JMS types
+
+        // MQMD properties require mq.message.mqmd.write=true
+        final DefaultMessageBuilder mqmdBuilder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        mqmdBuilder.configure(props);
+
+        final ConnectHeaders headers = new ConnectHeaders();
+
+        // New source converts all types to String (except byte[])
+        // MQMD Integer properties as String
+        headers.addString("JMS_IBM_MQMD_Priority", "5");
+        headers.addString("JMS_IBM_MQMD_Expiry", "36000");
+        headers.addString("JMS_IBM_MQMD_Encoding", "546");
+
+        // MQMD String properties as String
+        headers.addString("JMS_IBM_MQMD_Format", "MQSTR");
+        headers.addString("JMS_IBM_MQMD_ReplyToQ", "REPLY.QUEUE");
+
+        // JMS_IBM Boolean property as String
+        headers.addString("JMS_IBM_Last_Msg_In_Group", "true");
+
+        // JMS_IBM Integer properties as String
+        headers.addString("JMS_IBM_Encoding", "546");
+
+        // Standard JMS properties as String (NEW: these use dedicated setters)
+        headers.addString("JMS_DELIVERY_MODE", "2");
+        headers.addString("JMS_EXPIRATION", "60000");
+
+        // Only byte[] properties stay as byte[]
+        final byte[] groupId = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                                           0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+                                           0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18};
+        headers.add("JMS_IBM_MQMD_GroupId", groupId, Schema.OPTIONAL_BYTES_SCHEMA);
+
+        // Generate MQ message
+        final Message message = mqmdBuilder.fromSinkRecord(getJmsContext(), generateSinkRecord(headers));
+
+        // Verify sink correctly parses String back to proper types
+        // MQMD Integer properties
+        assertEquals(5, message.getIntProperty("JMS_IBM_MQMD_Priority"));
+        assertEquals(36000, message.getIntProperty("JMS_IBM_MQMD_Expiry"));
+        assertEquals(546, message.getIntProperty("JMS_IBM_MQMD_Encoding"));
+
+        // MQMD String properties
+        assertEquals("MQSTR", message.getStringProperty("JMS_IBM_MQMD_Format"));
+        assertEquals("REPLY.QUEUE", message.getStringProperty("JMS_IBM_MQMD_ReplyToQ"));
+
+        // JMS_IBM Boolean property
+        assertEquals(true, message.getBooleanProperty("JMS_IBM_Last_Msg_In_Group"));
+
+        // JMS_IBM Integer property
+        assertEquals(546, message.getIntProperty("JMS_IBM_Encoding"));
+
+        // Standard JMS properties (using dedicated setters)
+        assertEquals(2, message.getJMSDeliveryMode());
+        // assertEquals(60000L, message.getJMSExpiration());
+
+        // byte[] property
+        assertTrue(message.propertyExists("JMS_IBM_MQMD_GroupId"));
     }
 }

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MQSinkTaskHeadersDefaultIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MQSinkTaskHeadersDefaultIT.java
@@ -1,0 +1,380 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+
+import javax.jms.Message;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.storage.SimpleHeaderConverter;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.eventstreams.connect.mqsink.AbstractJMSContextIT;
+import com.ibm.msg.client.jms.JmsConstants;
+
+/**
+ * Integration tests for copying Kafka headers to JMS message properties
+ *  using the default Connect header converter.
+ */
+public class MQSinkTaskHeadersDefaultIT extends AbstractJMSContextIT {
+
+    private static final String TOPIC = "mytopic";
+
+    private static final byte[] TEST_CORREL_ID = new byte[] {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18
+    };
+
+    private MessageBuilder builder;
+    private HeaderConverter converter;
+
+    @Before
+    public void before() {
+        builder = new DefaultMessageBuilder();
+        final HashMap<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        builder.configure(props);
+
+        converter = new SimpleHeaderConverter();
+        final HashMap<String, String> converterConfig = new HashMap<>();
+        converter.configure(converterConfig);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a SinkRecord whose headers contain a single header reconstructed
+     * from wire bytes via SimpleHeaderConverter, recreating how Kafka Connect
+     * would deliver headers to a sink task.
+     */
+    private SinkRecord sinkRecordWithHeader(final String headerName, final byte[] wireBytes) {
+        final SchemaAndValue schemaAndValue = converter.toConnectHeader(TOPIC, headerName, wireBytes);
+        final ConnectHeaders headers = new ConnectHeaders();
+        headers.add(headerName, schemaAndValue);
+        return new SinkRecord(TOPIC, 0,
+                Schema.STRING_SCHEMA, "key",
+                Schema.STRING_SCHEMA, "value",
+                0L,
+                null, TimestampType.NO_TIMESTAMP_TYPE,
+                headers);
+    }
+
+    /**
+     * SimpleHeaderConverter writes scalar values as UTF-8 bytes of
+     * their string representation.
+     */
+    private SinkRecord sinkRecordWithStringHeader(final String headerName, final String headerString) {
+        return sinkRecordWithHeader(headerName, headerString.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    // =========================================================================
+    // User-defined message properties
+    // =========================================================================
+
+    @Test
+    public void userDefinedStringProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("strProp", "hello"));
+
+        assertThat(message.getStringProperty("strProp")).isEqualTo("hello");
+    }
+
+    @Test
+    public void userDefinedIntProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("intProp", "42"));
+
+        assertThat(message.getIntProperty("intProp")).isEqualTo(42);
+    }
+
+    @Test
+    public void userDefinedLongProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("longProp", "123456789012345"));
+
+        assertThat(message.getLongProperty("longProp")).isEqualTo(123456789012345L);
+    }
+
+    @Test
+    public void userDefinedFloatProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("floatProp", "1.5"));
+
+        assertThat(message.getFloatProperty("floatProp")).isEqualTo(1.5f);
+    }
+
+    @Test
+    public void userDefinedDoubleProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("doubleProp", "3.141592653589793"));
+
+        assertThat(message.getFloatProperty("doubleProp")).isEqualTo((float) 3.141592653589793);
+    }
+
+    @Test
+    public void userDefinedBooleanProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("boolProp", "true"));
+
+        assertThat(message.getBooleanProperty("boolProp")).isTrue();
+    }
+
+    @Test
+    public void userDefinedByteProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("byteProp", "64"));
+
+        assertThat(message.getByteProperty("byteProp")).isEqualTo((byte) 64);
+    }
+
+    @Test
+    public void userDefinedShortProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader("shortProp", "1000"));
+
+        assertThat(message.getShortProperty("shortProp")).isEqualTo((short) 1000);
+    }
+
+
+    // =========================================================================
+    // JMSx properties (standard JMS)
+    // =========================================================================
+
+    @Test
+    public void jmsxUserId() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMSX_USERID, "app"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMSX_USERID).trim()).isEqualTo("app");
+    }
+
+    @Test
+    public void jmsxGroupId() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMSX_GROUPID, "MY_GROUP"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMSX_GROUPID)).isEqualTo("MY_GROUP");
+    }
+
+    @Test
+    public void jmsxGroupSeq() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMSX_GROUPSEQ, "3"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMSX_GROUPSEQ)).isEqualTo(3);
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_* extension properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmFormat() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_FORMAT, "MQSTR"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_FORMAT).trim()).isEqualTo("MQSTR");
+    }
+
+    @Test
+    public void jmsIbmMsgType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MSGTYPE, "8"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MSGTYPE)).isEqualTo(8);
+    }
+
+    @Test
+    public void jmsIbmCharacterSet() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_CHARACTER_SET, "1208"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_CHARACTER_SET)).isEqualTo(1208);
+    }
+
+    @Test
+    public void jmsIbmEncoding() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_ENCODING, "273"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_ENCODING)).isEqualTo(273);
+    }
+
+    @Test
+    public void jmsIbmPutDate() throws Exception {
+        final String today = java.time.LocalDate.now()
+                .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_PUTDATE, today));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_PUTDATE)).isEqualTo(today);
+    }
+
+    @Test
+    public void jmsIbmPutTime() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_PUTTIME, "12345678"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_PUTTIME)).matches("\\d+");
+    }
+
+    @Test
+    public void jmsIbmPutApplType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_PUTAPPLTYPE, "28"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_PUTAPPLTYPE)).matches("\\d+");
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_MQMD_* properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmMqmdPutApplName() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME, "myapp"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME)).isNotEmpty();
+    }
+
+    @Test
+    public void jmsIbmMqmdPutDate() throws Exception {
+        final String today = java.time.LocalDate.now()
+                .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_PUTDATE, today));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTDATE)).isEqualTo(today);
+    }
+
+    @Test
+    public void jmsIbmMqmdPutTime() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_PUTTIME, "12345678"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTTIME)).matches("\\d+");
+    }
+
+    @Test
+    public void jmsIbmMqmdPriority() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_PRIORITY, "4"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_PRIORITY)).isEqualTo(4);
+    }
+
+    @Test
+    public void jmsIbmMqmdPersistence() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_PERSISTENCE, "1"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_PERSISTENCE)).isEqualTo(1);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_MSGTYPE, "8"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_MSGTYPE)).isEqualTo(8);
+    }
+
+    @Test
+    public void jmsIbmMqmdEncoding() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_ENCODING, "273"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_ENCODING)).isEqualTo(273);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgId() throws Exception {
+        final String msgId = "414D51207061756C745639344C545320EBC32F6A01FD0140";
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_MSGID, msgId));
+
+        final byte[] msgIdBytes = (byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(msgIdBytes).hasSize(24);
+        assertThat(msgIdBytes[0]).isEqualTo((byte)65);
+        assertThat(msgIdBytes[1]).isEqualTo((byte)77);
+        assertThat(msgIdBytes[22]).isEqualTo((byte)1);
+        assertThat(msgIdBytes[23]).isEqualTo((byte)64);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgIdPrefixed() throws Exception {
+        final String msgId = "ID:414D51207061756C745639344C545320EBC32F6A01FD0140";
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithStringHeader(JmsConstants.JMS_IBM_MQMD_MSGID, msgId));
+
+        final byte[] msgIdBytes = (byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(msgIdBytes).hasSize(24);
+        assertThat(msgIdBytes[0]).isEqualTo((byte)65);
+        assertThat(msgIdBytes[1]).isEqualTo((byte)77);
+        assertThat(msgIdBytes[22]).isEqualTo((byte)1);
+        assertThat(msgIdBytes[23]).isEqualTo((byte)64);
+    }    
+
+    @Test
+    public void jmsIbmMqmdCorrelId() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithHeader(JmsConstants.JMS_IBM_MQMD_CORRELID, TEST_CORREL_ID));
+
+        assertThat(message.getJMSCorrelationIDAsBytes()).isEqualTo(TEST_CORREL_ID);
+    }
+
+    @Test
+    public void jmsIbmMqmdAccountingToken() throws Exception {
+        final byte[] accountingToken = new byte[32];
+        Arrays.fill(accountingToken, (byte) 9);
+
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithHeader(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN, Base64.getEncoder().encode(accountingToken)));
+
+        assertThat((byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN)).isEqualTo(accountingToken);
+    }
+
+    @Test
+    public void jmsIbmMqmdGroupId() throws Exception {
+        final byte[] groupId = new byte[24];
+        Arrays.fill(groupId, (byte) 0);
+
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithHeader(JmsConstants.JMS_IBM_MQMD_GROUPID, Base64.getEncoder().encode(groupId)));
+
+        assertThat((byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_GROUPID)).isEqualTo(groupId);
+    }
+}

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MQSinkTaskHeadersJsonIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MQSinkTaskHeadersJsonIT.java
@@ -1,0 +1,344 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+
+import javax.jms.Message;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.eventstreams.connect.mqsink.AbstractJMSContextIT;
+import com.ibm.msg.client.jms.JmsConstants;
+
+/**
+ * Integration tests for copying Kafka headers to JMS message properties
+ *  using the JSON Connect header converter.
+ *
+ * JsonConverter is schema-sensitive so this is used to catch schema type 
+ *  bugs that using the default SimpleHeaderConverter cannot reveal.
+ */
+public class MQSinkTaskHeadersJsonIT extends AbstractJMSContextIT {
+
+    private static final String TOPIC = "mytopic";
+
+    private MessageBuilder builder;
+    private HeaderConverter converter;
+
+    @Before
+    public void before() {
+        builder = new DefaultMessageBuilder();
+        final HashMap<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        builder.configure(props);
+
+        converter = new JsonConverter();
+        final HashMap<String, String> converterConfig = new HashMap<>();
+        converterConfig.put("schemas.enable", "false");
+        converterConfig.put("converter.type", "header");
+        converter.configure(converterConfig);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a SinkRecord whose headers contain a single header reconstructed
+     * from wire bytes via JsonConverter, recreating how Kafka Connect
+     * would deliver headers to a sink task.
+     */
+    private SinkRecord sinkRecordWithHeader(final String headerName, final byte[] wireBytes) {
+        final SchemaAndValue schemaAndValue = converter.toConnectHeader(TOPIC, headerName, wireBytes);
+        final ConnectHeaders headers = new ConnectHeaders();
+        headers.add(headerName, schemaAndValue);
+        return new SinkRecord(TOPIC, 0,
+                Schema.STRING_SCHEMA, "key",
+                Schema.STRING_SCHEMA, "value",
+                0L,
+                null, TimestampType.NO_TIMESTAMP_TYPE,
+                headers);
+    }
+
+    /**
+     * JsonConverter (schemas.enable=false) serialising JSON data as UTF-8 bytes of 
+     * the string representation.
+     */
+    private SinkRecord sinkRecordWithJsonHeader(final String headerName, final String json) {
+        return sinkRecordWithHeader(headerName, json.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    // =========================================================================
+    // User-defined message properties
+    // =========================================================================
+
+    @Test
+    public void userDefinedStringProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("strProp", "\"hello\""));
+
+        assertThat(message.getStringProperty("strProp")).isEqualTo("hello");
+    }
+
+    @Test
+    public void userDefinedLongProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("longProp", "123456789012345"));
+
+        assertThat(message.getLongProperty("longProp")).isEqualTo(123456789012345L);
+    }
+
+    @Test
+    public void userDefinedDoubleProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("doubleProp", "3.141592653589793"));
+
+        assertThat(message.getDoubleProperty("doubleProp")).isEqualTo(3.141592653589793);
+    }
+
+    @Test
+    public void userDefinedBooleanProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("boolProp", "true"));
+
+        assertThat(message.getBooleanProperty("boolProp")).isTrue();
+    }
+
+    // =========================================================================
+    // JMSx properties (standard JMS)
+    // =========================================================================
+
+    @Test
+    public void jmsxUserId() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMSX_USERID, "\"app\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMSX_USERID)).isEqualTo("app");        
+    }
+
+    @Test
+    public void jmsxGroupId() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMSX_GROUPID, "\"MY_GROUP\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMSX_GROUPID)).isEqualTo("MY_GROUP");
+    }
+
+    @Test
+    public void jmsxGroupSeq() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMSX_GROUPSEQ, "3"));
+
+        assertThat(message.getLongProperty(JmsConstants.JMSX_GROUPSEQ)).isEqualTo(3);
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_* extension properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmFormat() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_FORMAT, "\"MQSTR\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_FORMAT).trim()).isEqualTo("MQSTR");
+    }
+
+    @Test
+    public void jmsIbmMsgType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MSGTYPE, "8"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MSGTYPE)).isEqualTo(8);
+    }
+
+    @Test
+    public void jmsIbmCharacterSet() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_CHARACTER_SET, "1208"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_CHARACTER_SET)).isEqualTo(1208);
+    }
+
+    @Test
+    public void jmsIbmEncoding() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_ENCODING, "273"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_ENCODING)).isEqualTo(273);
+    }
+
+    @Test
+    public void jmsIbmPutDate() throws Exception {
+        final String today = java.time.LocalDate.now()
+                .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_PUTDATE, "\"" + today + "\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_PUTDATE)).isEqualTo(today);
+    }
+
+    @Test
+    public void jmsIbmPutTime() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_PUTTIME, "\"12345678\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_PUTTIME)).matches("\\d+");
+    }    
+
+    @Test
+    public void jmsIbmPutApplType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_PUTAPPLTYPE, "28"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_PUTAPPLTYPE)).isEqualTo(28);
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_MQMD_* properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmMqmdPutApplName() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME, "\"myapp\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME)).isNotEmpty();
+    }
+
+    @Test
+    public void jmsIbmMqmdPutDate() throws Exception {
+        final String today = java.time.LocalDate.now()
+                .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PUTDATE, "\"" + today + "\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTDATE)).isEqualTo(today);
+    }
+
+    @Test
+    public void jmsIbmMqmdPutTime() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PUTTIME, "\"12345678\""));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTTIME)).matches("\\d+");
+    }
+
+    @Test
+    public void jmsIbmMqmdPriority() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PRIORITY, "4"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_PRIORITY)).isEqualTo(4);
+    }
+
+    @Test
+    public void jmsIbmMqmdPersistence() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PERSISTENCE, "1"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_PERSISTENCE)).isEqualTo(1);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_MSGTYPE, "8"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_MSGTYPE)).isEqualTo(8);
+    }
+
+    @Test
+    public void jmsIbmMqmdEncoding() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_ENCODING, "273"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_ENCODING)).isEqualTo(273);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgId() throws Exception {
+        final String msgId = "414D51207061756C745639344C545320EBC32F6A01FD0140";
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_MSGID, "\"" + msgId + "\""));
+
+        final byte[] msgIdBytes = (byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(msgIdBytes).hasSize(24);
+        assertThat(msgIdBytes[0]).isEqualTo((byte)65);
+        assertThat(msgIdBytes[1]).isEqualTo((byte)77);
+        assertThat(msgIdBytes[22]).isEqualTo((byte)1);
+        assertThat(msgIdBytes[23]).isEqualTo((byte)64);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgIdPrefixed() throws Exception {
+        final String msgId = "414D51207061756C745639344C545320EBC32F6A01FD0140";
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_MSGID, "\"ID:" + msgId + "\""));
+
+        final byte[] msgIdBytes = (byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(msgIdBytes).hasSize(24);
+        assertThat(msgIdBytes[0]).isEqualTo((byte)65);
+        assertThat(msgIdBytes[1]).isEqualTo((byte)77);
+        assertThat(msgIdBytes[22]).isEqualTo((byte)1);
+        assertThat(msgIdBytes[23]).isEqualTo((byte)64);
+    }
+
+    @Test
+    public void jmsIbmMqmdCorrelId() throws Exception {
+        final String correlId = "0102030405060708090A0B0C0D0E0F101112131415161718";
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_CORRELID, "\"" + correlId + "\""));
+        
+        assertThat(message.getJMSCorrelationID()).isEqualTo(correlId);
+    }
+
+    @Test
+    public void jmsIbmMqmdAccountingToken() throws Exception {
+        final byte[] accountingToken = new byte[32];
+        final String base64Json = "\"" + Base64.getEncoder().encodeToString(accountingToken) + "\"";
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN, base64Json));
+
+        assertThat((byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN)).hasSize(32);
+    }
+
+    @Test
+    public void jmsIbmMqmdGroupId() throws Exception {
+        final byte[] groupId = new byte[24];
+        final String base64Json = "\"" + Base64.getEncoder().encodeToString(groupId) + "\"";
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_GROUPID, base64Json));
+
+        assertThat((byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_GROUPID)).hasSize(24);
+    }
+}

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MQSinkTaskHeadersSchemaIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MQSinkTaskHeadersSchemaIT.java
@@ -1,0 +1,422 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+
+import javax.jms.Message;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.eventstreams.connect.mqsink.AbstractJMSContextIT;
+import com.ibm.msg.client.jms.JmsConstants;
+
+/**
+ * Integration tests for copying Kafka headers to JMS message properties
+ *  using the JSON Connect header converter.
+ *
+ * JsonConverter is schema-sensitive so this is used to catch schema type 
+ *  bugs that using the default SimpleHeaderConverter cannot reveal.
+ */
+public class MQSinkTaskHeadersSchemaIT extends AbstractJMSContextIT {
+
+    private static final String TOPIC = "mytopic";
+
+    private MessageBuilder builder;
+    private HeaderConverter converter;
+
+    @Before
+    public void before() {
+        builder = new DefaultMessageBuilder();
+        final HashMap<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.write", "true");
+        builder.configure(props);
+
+        converter = new JsonConverter();
+        final HashMap<String, String> converterConfig = new HashMap<>();
+        converterConfig.put("schemas.enable", "true");
+        converterConfig.put("converter.type", "header");
+        converter.configure(converterConfig);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a SinkRecord whose headers contain a single header reconstructed
+     * from wire bytes via JsonConverter, recreating how Kafka Connect
+     * would deliver headers to a sink task.
+     */
+    private SinkRecord sinkRecordWithHeader(final String headerName, final byte[] wireBytes) {
+        final SchemaAndValue schemaAndValue = converter.toConnectHeader(TOPIC, headerName, wireBytes);
+        final ConnectHeaders headers = new ConnectHeaders();
+        headers.add(headerName, schemaAndValue);
+        return new SinkRecord(TOPIC, 0,
+                Schema.STRING_SCHEMA, "key",
+                Schema.STRING_SCHEMA, "value",
+                0L,
+                null, TimestampType.NO_TIMESTAMP_TYPE,
+                headers);
+    }
+
+    private SinkRecord sinkRecordWithJsonHeader(final String headerName, final String json) {
+        return sinkRecordWithHeader(headerName, json.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    // =========================================================================
+    // User-defined message properties
+    // =========================================================================
+
+    @Test
+    public void userDefinedStringProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("strProp",
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"hello\"}"));
+
+        assertThat(message.getStringProperty("strProp")).isEqualTo("hello");
+    }
+
+    @Test
+    public void userDefinedByteProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("byteProp", 
+                "{\"schema\":{\"type\":\"int8\"},\"payload\": 64 }"));
+
+        assertThat(message.getByteProperty("byteProp")).isEqualTo((byte) 64);
+    }
+
+    @Test
+    public void userDefinedShortProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("intProp", 
+                "{\"schema\":{\"type\":\"int16\"},\"payload\": 1000 }"));
+
+        assertThat(message.getShortProperty("intProp")).isEqualTo((short) 1000);
+    }
+
+    @Test
+    public void userDefinedIntProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("intProp", 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 12345 }"));
+
+        assertThat(message.getLongProperty("intProp")).isEqualTo(12345);
+    }
+
+    @Test
+    public void userDefinedLongProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("longProp", 
+                "{\"schema\":{\"type\":\"int64\"},\"payload\": 123456789012345 }"));
+
+        assertThat(message.getLongProperty("longProp")).isEqualTo(123456789012345L);
+    }
+
+    @Test
+    public void userDefinedFloatProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("floatProp", 
+                "{\"schema\":{\"type\":\"float\"},\"payload\": 3.14 }"));
+
+        assertThat(message.getFloatProperty("floatProp")).isEqualTo(3.14f);
+    }
+
+    @Test
+    public void userDefinedDoubleProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("doubleProp", 
+                "{\"schema\":{\"type\":\"double\"},\"payload\": 3.141592653589793 }"));
+
+        assertThat(message.getDoubleProperty("doubleProp")).isEqualTo((double) 3.141592653589793);
+    }
+
+    @Test
+    public void userDefinedBooleanProperty() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader("boolProp", 
+                "{\"schema\":{\"type\":\"boolean\"},\"payload\": true }"));
+
+        assertThat(message.getBooleanProperty("boolProp")).isTrue();
+    }
+
+    // =========================================================================
+    // JMSx properties (standard JMS)
+    // =========================================================================
+
+    @Test
+    public void jmsxUserId() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMSX_USERID,
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"app\"}"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMSX_USERID)).isEqualTo("app");        
+    }
+
+    @Test
+    public void jmsxGroupId() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMSX_GROUPID,
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"MY_GROUP\"}"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMSX_GROUPID)).isEqualTo("MY_GROUP");
+    }
+
+    @Test
+    public void jmsxGroupSeq() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMSX_GROUPSEQ,
+                "{\"schema\":{\"type\":\"int8\"},\"payload\": 3 }"));
+
+        assertThat(message.getLongProperty(JmsConstants.JMSX_GROUPSEQ)).isEqualTo(3);
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_* extension properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmFormat() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_FORMAT,
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"MQSTR\"}"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_FORMAT).trim()).isEqualTo("MQSTR");
+    }
+
+    @Test
+    public void jmsIbmMsgType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MSGTYPE, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 8 }"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MSGTYPE)).isEqualTo(8);
+    }
+
+    @Test
+    public void jmsIbmCharacterSet() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_CHARACTER_SET, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\":1208}"));
+                    
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_CHARACTER_SET)).isEqualTo(1208);
+    }
+
+    @Test
+    public void jmsIbmEncoding() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_ENCODING, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 273 }"));
+                    
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_ENCODING)).isEqualTo(273);
+    }
+
+    @Test
+    public void jmsIbmPutDate() throws Exception {
+        final String today = java.time.LocalDate.now()
+                .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_PUTDATE, 
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"" + today + "\"}"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_PUTDATE)).isEqualTo(today);
+    }
+
+    @Test
+    public void jmsIbmPutTime() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_PUTTIME, 
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"12345678\"}"));
+                    
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_PUTTIME)).matches("\\d+");
+    }    
+
+    @Test
+    public void jmsIbmPutApplType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_PUTAPPLTYPE, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 28 }"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_PUTAPPLTYPE)).isEqualTo(28);
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_MQMD_* properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmMqmdPutApplName() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME, 
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"myapp\"}"));
+                    
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME)).isNotEmpty();
+    }
+
+    @Test
+    public void jmsIbmMqmdPutDate() throws Exception {
+        final String today = java.time.LocalDate.now()
+                .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PUTDATE, 
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"" + today + "\"}"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTDATE)).isEqualTo(today);
+    }
+
+    @Test
+    public void jmsIbmMqmdPutTime() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PUTTIME, 
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"12345678\"}"));
+
+        assertThat(message.getStringProperty(JmsConstants.JMS_IBM_MQMD_PUTTIME)).matches("\\d+");
+    }
+
+    @Test
+    public void jmsIbmMqmdPriority() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PRIORITY, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 4 }"));
+                    
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_PRIORITY)).isEqualTo(4);
+    }
+
+    @Test
+    public void jmsIbmMqmdPersistence() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_PERSISTENCE, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 1 }"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_PERSISTENCE)).isEqualTo(1);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgType() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_MSGTYPE, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 8 }"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_MSGTYPE)).isEqualTo(8);
+    }
+
+    @Test
+    public void jmsIbmMqmdEncoding() throws Exception {
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_ENCODING, 
+                "{\"schema\":{\"type\":\"int32\"},\"payload\": 273 }"));
+
+        assertThat(message.getIntProperty(JmsConstants.JMS_IBM_MQMD_ENCODING)).isEqualTo(273);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgIdBytes() throws Exception {
+        final byte[] msgId = { 0x41, 0x4D, 0x51, 0x20, 0x70, 0x61, 0x75, 0x6C, 
+                               0x74, 0x56, 0x39, 0x34, 0x4C, 0x54, 0x53, 0x20, 
+                               0x22, 0x23, 0x2F, 0x6A, 0x01, 0x2D, 0x01, 0x40 }; 
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_MSGID, 
+                "{\"schema\":{\"type\":\"bytes\"},\"payload\":\"" + 
+                    Base64.getEncoder().encodeToString(msgId) + 
+                    "\" }"));
+
+        final byte[] msgIdBytes = (byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(msgIdBytes).hasSize(24);
+        assertThat(msgIdBytes).isEqualTo(msgId);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgIdString() throws Exception {
+        final byte[] msgId = { 0x41, 0x4D, 0x51, 0x20, 0x70, 0x61, 0x75, 0x6C, 
+                               0x74, 0x56, 0x39, 0x34, 0x4C, 0x54, 0x53, 0x20, 
+                               0x22, 0x23, 0x2F, 0x6A, 0x01, 0x2D, 0x01, 0x40 }; 
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_MSGID, 
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"414D51207061756C745639344C54532022232F6A012D0140\" }"));
+
+        final byte[] msgIdBytes = (byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(msgIdBytes).hasSize(24);
+        assertThat(msgIdBytes).isEqualTo(msgId);
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgIdPrefixed() throws Exception {
+        final byte[] msgId = { 0x41, 0x4D, 0x51, 0x20, 0x70, 0x61, 0x75, 0x6C, 
+                               0x74, 0x56, 0x39, 0x34, 0x4C, 0x54, 0x53, 0x20, 
+                               0x22, 0x23, 0x2F, 0x6A, 0x01, 0x2D, 0x01, 0x40 }; 
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_MSGID, 
+                "{\"schema\":{\"type\":\"string\"},\"payload\":\"ID:414D51207061756C745639344C54532022232F6A012D0140\" }"));
+
+        final byte[] msgIdBytes = (byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(msgIdBytes).hasSize(24);
+        assertThat(msgIdBytes).isEqualTo(msgId);
+    }
+
+    @Test
+    public void jmsIbmMqmdCorrelId() throws Exception {
+        final byte[] correlId = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 
+                                  0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 
+                                  0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18 };
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_CORRELID, 
+                "{\"schema\":{\"type\":\"bytes\"},\"payload\":\"" + 
+                    Base64.getEncoder().encodeToString(correlId) + 
+                    "\" }"));
+        
+        assertThat(message.getJMSCorrelationIDAsBytes()).isEqualTo(correlId);
+    }
+
+    @Test
+    public void jmsIbmMqmdAccountingToken() throws Exception {
+        final byte[] accountingToken = new byte[32];
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN, 
+                "{\"schema\":{\"type\":\"bytes\"},\"payload\":\"" + 
+                    Base64.getEncoder().encodeToString(accountingToken) + 
+                    "\" }"));
+
+        assertThat((byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN)).hasSize(32);
+    }
+
+    @Test
+    public void jmsIbmMqmdGroupId() throws Exception {
+        final byte[] groupId = new byte[24];
+        final Message message = builder.fromSinkRecord(getJmsContext(),
+                sinkRecordWithJsonHeader(JmsConstants.JMS_IBM_MQMD_GROUPID, 
+                "{\"schema\":{\"type\":\"bytes\"},\"payload\":\"" + 
+                    Base64.getEncoder().encodeToString(groupId) + 
+                    "\" }"));
+
+        assertThat((byte[]) message.getObjectProperty(JmsConstants.JMS_IBM_MQMD_GROUPID)).hasSize(24);
+    }
+}

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkConnector.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class MQSinkConnector extends SinkConnector {
     private static final Logger log = LoggerFactory.getLogger(MQSinkConnector.class);
 
-    public static String version = "2.2.1";
+    public static String version = "2.3.0";
 
     private Map<String, String> configProps;
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
@@ -113,7 +113,6 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
             mqmdWriteEnabled = Boolean.valueOf(mqmdWrite);
         }
 
-        // Configure the header converter with MQMD write setting and context
         headerConverter.setMqmdWriteEnabled(mqmdWriteEnabled);
 
         log.trace("[{}]  Exit {}.configure", Thread.currentThread().getId(), this.getClass().getName());
@@ -128,6 +127,7 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
      * @return the JMS message
      */
     public abstract Message getJMSMessage(JMSContext jmsCtxt, SinkRecord record);
+
 
     /**
      * Sets a JMS message property from a Kafka Connect header with IBM MQ-aware type handling.
@@ -232,7 +232,7 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
         if (copyJmsProperties) {
             for (final Header header : record.headers()) {
                 try {
-                    setJmsProperty(m, header);
+                    headerConverter.copyHeaderToJmsProperty(m, header);
                 } catch (final IllegalArgumentException iae) {
                     // Bad header name or unconvertible value — skip and continue
                     log.warn("Skipping header '{}': {}", header.key(), iae.getMessage());

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, 2019, 2023, 2024 IBM Corporation
+ * Copyright 2018, 2019, 2023, 2024, 2026 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 package com.ibm.eventstreams.connect.mqsink.builders;
 
 import com.ibm.eventstreams.connect.mqsink.MQSinkConfig;
-
 import com.ibm.mq.jms.MQQueue;
 
 import java.nio.ByteBuffer;
-import java.util.Iterator;
 import java.util.Map;
 
 import javax.jms.Destination;
@@ -50,6 +48,10 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
     public String partitionPropertyName;
     public String offsetPropertyName;
     public boolean copyJmsProperties;
+    public boolean mqmdWriteEnabled;
+
+    // Converter for Kafka headers to JMS properties
+    private final KafkaToJmsHeaderConverter headerConverter = new KafkaToJmsHeaderConverter();
 
     /**
      * Configure this class.
@@ -106,6 +108,14 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
             copyJmsProperties = Boolean.valueOf(copyhdr);
         }
 
+        final String mqmdWrite = props.get(MQSinkConfig.CONFIG_NAME_MQ_MQMD_WRITE_ENABLED);
+        if (mqmdWrite != null) {
+            mqmdWriteEnabled = Boolean.valueOf(mqmdWrite);
+        }
+
+        // Configure the header converter with MQMD write setting and context
+        headerConverter.setMqmdWriteEnabled(mqmdWriteEnabled);
+
         log.trace("[{}]  Exit {}.configure", Thread.currentThread().getId(), this.getClass().getName());
     }
 
@@ -120,6 +130,20 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
     public abstract Message getJMSMessage(JMSContext jmsCtxt, SinkRecord record);
 
     /**
+     * Sets a JMS message property from a Kafka Connect header with IBM MQ-aware type handling.
+     * Uses KafkaToJmsHeaderConverter to convert Kafka header values to the appropriate JMS property types.
+     * Supports both new Source Connector (typed values) and old Source Connector (String values).
+     *
+     * @param message the JMS message to set the property on
+     * @param header  the Kafka Connect header
+     * @throws ConnectException  if the value type is not compatible with the expected property type
+     */
+    private void setJmsProperty(final Message message, final Header header) {
+        headerConverter.copyHeaderToJmsProperty(message, header);
+    }
+
+
+    /**
      * Convert a Kafka Connect SinkRecord into a JMS message.
      *
      * @param context            the JMS context to use for building messages
@@ -129,6 +153,7 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
      */
     @Override public Message fromSinkRecord(final JMSContext jmsCtxt, final SinkRecord record) {
         final Message m = this.getJMSMessage(jmsCtxt, record);
+
 
         if (keyheader != KeyHeader.NONE) {
             final Schema s = record.keySchema();
@@ -180,14 +205,6 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
             }
         }
 
-        if (replyToQueue != null) {
-            try {
-                m.setJMSReplyTo(replyToQueue);
-            } catch (final JMSException jmse) {
-                throw new ConnectException("Failed to set reply-to queue", jmse);
-            }
-        }
-
         if (topicPropertyName != null) {
             try {
                 m.setStringProperty(topicPropertyName, record.topic());
@@ -213,13 +230,23 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
         }
 
         if (copyJmsProperties) {
-            for (Iterator<Header> iterator = record.headers().iterator(); iterator.hasNext();) {
-                final Header header = iterator.next();
+            for (final Header header : record.headers()) {
                 try {
-                    m.setStringProperty(header.key(), header.value().toString());
-                } catch (final JMSException jmse) {
-                    throw new ConnectException("Failed to set header", jmse);
+                    setJmsProperty(m, header);
+                } catch (final IllegalArgumentException iae) {
+                    // Bad header name or unconvertible value — skip and continue
+                    log.warn("Skipping header '{}': {}", header.key(), iae.getMessage());
                 }
+            }
+        }
+
+        // Set the JMSReplyTo property if a reply-to queue is configured, if it exists.
+        // This overrides the reply-to queue set from the JMSReplyTo header from source Kafka Connect record.
+        if (replyToQueue != null) {
+            try {
+                m.setJMSReplyTo(replyToQueue);
+            } catch (final JMSException jmse) {
+                throw new ConnectException("Failed to set reply-to queue", jmse);
             }
         }
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/BaseMessageBuilder.java
@@ -128,21 +128,6 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
      */
     public abstract Message getJMSMessage(JMSContext jmsCtxt, SinkRecord record);
 
-
-    /**
-     * Sets a JMS message property from a Kafka Connect header with IBM MQ-aware type handling.
-     * Uses KafkaToJmsHeaderConverter to convert Kafka header values to the appropriate JMS property types.
-     * Supports both new Source Connector (typed values) and old Source Connector (String values).
-     *
-     * @param message the JMS message to set the property on
-     * @param header  the Kafka Connect header
-     * @throws ConnectException  if the value type is not compatible with the expected property type
-     */
-    private void setJmsProperty(final Message message, final Header header) {
-        headerConverter.copyHeaderToJmsProperty(message, header);
-    }
-
-
     /**
      * Convert a Kafka Connect SinkRecord into a JMS message.
      *
@@ -153,57 +138,6 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
      */
     @Override public Message fromSinkRecord(final JMSContext jmsCtxt, final SinkRecord record) {
         final Message m = this.getJMSMessage(jmsCtxt, record);
-
-
-        if (keyheader != KeyHeader.NONE) {
-            final Schema s = record.keySchema();
-            final Object k = record.key();
-
-            if (k != null) {
-                if (s == null) {
-                    log.debug("No schema info {}", k);
-                    if (k instanceof byte[]) {
-                        try {
-                            m.setJMSCorrelationIDAsBytes((byte[]) k);
-                        } catch (final JMSException jmse) {
-                            throw new ConnectException("Failed to write bytes", jmse);
-                        }
-                    } else if (k instanceof ByteBuffer) {
-                        try {
-                            m.setJMSCorrelationIDAsBytes(((ByteBuffer) k).array());
-                        } catch (final JMSException jmse) {
-                            throw new ConnectException("Failed to write bytes", jmse);
-                        }
-                    } else {
-                        try {
-                            m.setJMSCorrelationID(k.toString());
-                        } catch (final JMSException jmse) {
-                            throw new ConnectException("Failed to write bytes", jmse);
-                        }
-                    }
-                } else if (s.type() == Type.BYTES) {
-                    if (k instanceof byte[]) {
-                        try {
-                            m.setJMSCorrelationIDAsBytes((byte[]) k);
-                        } catch (final JMSException jmse) {
-                            throw new ConnectException("Failed to write bytes", jmse);
-                        }
-                    } else if (k instanceof ByteBuffer) {
-                        try {
-                            m.setJMSCorrelationIDAsBytes(((ByteBuffer) k).array());
-                        } catch (final JMSException jmse) {
-                            throw new ConnectException("Failed to write bytes", jmse);
-                        }
-                    }
-                } else if (s.type() == Type.STRING) {
-                    try {
-                        m.setJMSCorrelationID((String) k);
-                    } catch (final JMSException jmse) {
-                        throw new ConnectException("Failed to write string", jmse);
-                    }
-                }
-            }
-        }
 
         if (topicPropertyName != null) {
             try {
@@ -240,6 +174,10 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
             }
         }
 
+        if (keyheader != KeyHeader.NONE) {
+            setJmsCorrelationIDBasedOnKeyheader(record, m);
+        }
+
         // Set the JMSReplyTo property if a reply-to queue is configured, if it exists.
         // This overrides the reply-to queue set from the JMSReplyTo header from source Kafka Connect record.
         if (replyToQueue != null) {
@@ -251,5 +189,55 @@ public abstract class BaseMessageBuilder implements MessageBuilder {
         }
 
         return m;
+    }
+
+    private void setJmsCorrelationIDBasedOnKeyheader(final SinkRecord record, final Message m) {
+        final Schema s = record.keySchema();
+        final Object k = record.key();
+
+        if (k != null) {
+            if (s == null) {
+                log.debug("No schema info {}", k);
+                if (k instanceof byte[]) {
+                    try {
+                        m.setJMSCorrelationIDAsBytes((byte[]) k);
+                    } catch (final JMSException jmse) {
+                        throw new ConnectException("Failed to write bytes", jmse);
+                    }
+                } else if (k instanceof ByteBuffer) {
+                    try {
+                        m.setJMSCorrelationIDAsBytes(((ByteBuffer) k).array());
+                    } catch (final JMSException jmse) {
+                        throw new ConnectException("Failed to write bytes", jmse);
+                    }
+                } else {
+                    try {
+                        m.setJMSCorrelationID(k.toString());
+                    } catch (final JMSException jmse) {
+                        throw new ConnectException("Failed to write bytes", jmse);
+                    }
+                }
+            } else if (s.type() == Type.BYTES) {
+                if (k instanceof byte[]) {
+                    try {
+                        m.setJMSCorrelationIDAsBytes((byte[]) k);
+                    } catch (final JMSException jmse) {
+                        throw new ConnectException("Failed to write bytes", jmse);
+                    }
+                } else if (k instanceof ByteBuffer) {
+                    try {
+                        m.setJMSCorrelationIDAsBytes(((ByteBuffer) k).array());
+                    } catch (final JMSException jmse) {
+                        throw new ConnectException("Failed to write bytes", jmse);
+                    }
+                }
+            } else if (s.type() == Type.STRING) {
+                try {
+                    m.setJMSCorrelationID((String) k);
+                } catch (final JMSException jmse) {
+                    throw new ConnectException("Failed to write string", jmse);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/HexUtils.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/HexUtils.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+/**
+ * Utility methods for hex string conversion.
+ *
+ * <p>This class exists as a polyfill for {@link java.util.HexFormat}, which was introduced
+ * in Java 17. It can be retired once this project's minimum Java version is raised to 17
+ * or above.
+ *
+ * <p>TODO: Replace {@link #hexStringToBytes(String)} with {@code HexFormat.of().parseHex(hex)}
+ * and delete this class when the project upgrades to Java 17+.
+ */
+public final class HexUtils {
+
+    private HexUtils() {}
+
+    /**
+     * Decodes a lowercase or uppercase hex string into a byte array.
+     *
+     * @param hex an even-length string of hexadecimal characters
+     * @return the decoded bytes
+     * @throws IllegalArgumentException if the string has odd length or contains non-hex characters
+     */
+    public static byte[] hexStringToBytes(final String hex) {
+        if (hex.length() % 2 != 0) {
+            throw new IllegalArgumentException("Invalid hex string (odd length): '" + hex + "'");
+        }
+        final byte[] bytes = new byte[hex.length() / 2];
+        for (int i = 0; i < hex.length(); i += 2) {
+            final int high = Character.digit(hex.charAt(i), 16);
+            final int low  = Character.digit(hex.charAt(i + 1), 16);
+            if (high == -1 || low == -1) {
+                throw new IllegalArgumentException("Invalid hex character at position " + i + " in '" + hex + "'");
+            }
+            bytes[i / 2] = (byte) ((high << 4) | low);
+        }
+        return bytes;
+    }
+}

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverter.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverter.java
@@ -23,8 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashSet;
-import java.util.HexFormat;
 import java.util.Set;
 
 import javax.jms.JMSException;
@@ -33,16 +33,12 @@ import javax.jms.Message;
 /**
  * Copies Kafka Connect headers to JMS message properties.
  *
- * Supports both legacy deployments where headers arrive as strings (for example from older
- * MQ source connector versions) and typed headers produced by schema-aware connectors.
- *
  * See: https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=application-jms-message-object-properties
  * See: https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=messages-jms-fields-properties-corresponding-mqmd-fields
  * IBM MQ JMS message object properties
  */
 public class KafkaToJmsHeaderConverter {
     private static final Logger log = LoggerFactory.getLogger(KafkaToJmsHeaderConverter.class);
-    private static final HexFormat HEX_FORMAT = HexFormat.of();
 
     private boolean mqmdWriteEnabled = false;
 
@@ -61,7 +57,6 @@ public class KafkaToJmsHeaderConverter {
      * - JMS_IBM_MQMD_Priority: Values outside 0-9 range violate JMS specification
      * - JMS_IBM_MQMD_BackoutCount: Value can't be set by the connector. Any value set is ignored
      * - JMS_IBM_MQMD_PutApplType: Requires WMQ_MQMD_MESSAGE_CONTEXT to be set to ALL context
-     * - These properties are IBM MQ extensions and may not be fully JMS-compliant
      * - The connector passes values through; IBM MQ will validate/reject invalid values
      */
     private static final Set<String> MQMD_INTEGER_PROPERTIES = new HashSet<>(Arrays.asList(
@@ -94,7 +89,7 @@ public class KafkaToJmsHeaderConverter {
             JmsConstants.JMS_IBM_MQMD_USERIDENTIFIER,
             JmsConstants.JMS_IBM_MQMD_APPLIDENTITYDATA,
             JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME,
-            JmsConstants.JMS_IBM_MQMD_PUTDATE,
+            JmsConstants.JMS_IBM_MQMD_PUTDATE,            
             JmsConstants.JMS_IBM_MQMD_PUTTIME,
             JmsConstants.JMS_IBM_MQMD_APPLORIGINDATA
     ));
@@ -103,9 +98,14 @@ public class KafkaToJmsHeaderConverter {
      * MQMD properties that require byte array type according to IBM MQ JMS specification.
      *
      * IMPORTANT: AccountingToken requires WMQ_MQMD_MESSAGE_CONTEXT to be set to IDENTITY or ALL context.
+     *
+     * When these properties are received from the default SimpleHeaderConverter, the source
+     * connector serializes the byte[] as Base64 (via Values.convertToString), so the connector 
+     * receives a Base64-encoded String which must be decoded back to byte[].
+     * When using ByteArrayConverter or JsonConverter, the byte[] arrives as-is.
      */
     private static final Set<String> MQMD_BYTES_PROPERTIES = new HashSet<>(Arrays.asList(
-            JmsConstants.JMS_IBM_MQMD_CORRELID,
+            // JmsConstants.JMS_IBM_MQMD_CORRELID, - this can be set by setJMSCorrelationID 
             JmsConstants.JMS_IBM_MQMD_MSGID,
             JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN,
             JmsConstants.JMS_IBM_MQMD_GROUPID
@@ -132,6 +132,7 @@ public class KafkaToJmsHeaderConverter {
      * Only settable properties are included here.
      */
     private static final Set<String> JMS_IBM_INTEGER_PROPERTIES = new HashSet<>(Arrays.asList(
+            JmsConstants.JMS_IBM_CHARACTER_SET,
             JmsConstants.JMS_IBM_REPORT_EXCEPTION,
             JmsConstants.JMS_IBM_REPORT_EXPIRATION,
             JmsConstants.JMS_IBM_REPORT_COA,
@@ -149,11 +150,11 @@ public class KafkaToJmsHeaderConverter {
 
     /**
      * JMS_IBM properties (non-MQMD) that require String type.
-     * Note: JMS_IBM_PutAppl, JMS_IBM_PutDate, JMS_IBM_PutTime are read-only and cannot be set.
      */
-    @SuppressWarnings("unused")
     private static final Set<String> JMS_IBM_STRING_PROPERTIES = new HashSet<>(Arrays.asList(
             JmsConstants.JMS_IBM_FORMAT,
+            JmsConstants.JMS_IBM_PUTDATE,
+            JmsConstants.JMS_IBM_PUTTIME,
             JmsConstants.JMS_IBM_CHARACTER_SET
     ));
 
@@ -164,18 +165,31 @@ public class KafkaToJmsHeaderConverter {
             JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP
     ));
 
-    private static final Set<Object> MQMD_PROPERTIES_TO_IGNORE = new HashSet<>(Arrays.asList(
-            // Value can't be set by the connector. Any value set is ignored.
+    private static final Set<String> MQMD_PROPERTIES_TO_IGNORE = new HashSet<>(Arrays.asList(
+            // Value that should not be set by the connector
             JmsConstants.JMS_IBM_MQMD_BACKOUTCOUNT
     ));
+
+    /**
+     * Java types accepted by {@link javax.jms.Message#setObjectProperty}.
+     * Any user-defined property value whose class is not in this set must be
+     * converted to String before being passed to setObjectProperty.
+     */
+    private static final Set<Class<?>> JMS_SUPPORTED_TYPES = new HashSet<>(Arrays.asList(
+            Boolean.class, Byte.class, Short.class,
+            Integer.class, Long.class, Float.class,
+            Double.class, String.class
+    ));    
+
+
 
     /**
      * Copies a Kafka Connect header to a JMS message property with type-correct conversion.
      *
      * The IBM MQ JMS specification requires specific Java types for MQMD and JMS_IBM
-     * properties. This method handles type coercion from both string-typed legacy headers
-     * and typed headers produced by schema-aware connectors.
-     *
+     * properties. This method ensures values from Kafka headers are coerced into the
+     * correct types. 
+     * 
      * @param message the target JMS message
      * @param header  the source Kafka Connect header
      * @throws IllegalArgumentException if the property name is illegal or value conversion fails
@@ -219,36 +233,46 @@ public class KafkaToJmsHeaderConverter {
             throws JMSException {
 
         if (JmsConstants.JMS_IBM_MQMD_CORRELID.equals(key)) {
-            message.setJMSCorrelationID(value.toString());
+            if (value instanceof byte[]) {
+                message.setJMSCorrelationIDAsBytes((byte[]) value);
+            } else {
+                String valueString = value.toString();
+                if (valueString.startsWith("ID:")) {
+                    valueString = valueString.substring(3);
+                }
+
+                message.setJMSCorrelationID(valueString);
+            }
             return;
         }
 
         if (JmsConstants.JMS_IBM_MQMD_MSGID.equals(key)) {
-            String hexString = value.toString();
-            // MQ automatically appends "ID:" to JMS_IBM_MQMD_MSGID, so strip it if present
-            if (hexString.startsWith("ID:")) {
-                hexString = hexString.substring(3);
+            if (value instanceof byte[]) {
+                message.setObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID, value);
+            } else {
+                String hexString = value.toString();
+                if (hexString.startsWith("ID:")) {
+                    hexString = hexString.substring(3);
+                }
+                
+                final byte[] msgIdBytes = HexUtils.hexStringToBytes(hexString);
+
+                message.setObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID, msgIdBytes);
             }
-            final byte[] msgIdBytes = HEX_FORMAT.parseHex(hexString);
-            message.setObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID, msgIdBytes);
             return;
         }
 
-
         final Object converted = convertToJmsType(key, value);
         message.setObjectProperty(key, converted);
-        log.debug("Set property '{}' as {}: {}",
-                key,
-                converted == null ? null : converted.getClass().getSimpleName(),
-                converted);
+        log.debug("Set property '{}' as {}", key, converted);
     }
 
     /**
      * Converts a Kafka header value to the Java type required by the IBM MQ JMS specification
      * for the given property key.
      *
-     * If the value is already the correct type (e.g., a typed header from a schema-aware
-     * connector), it is returned as-is. String values are coerced to the required type.
+     * If the value is already the correct type, it is returned as-is. 
+     * String values are coerced to the required type.
      *
      * @param key   the JMS property name
      * @param value the raw value from the Kafka header
@@ -268,19 +292,36 @@ public class KafkaToJmsHeaderConverter {
         if (MQMD_STRING_PROPERTIES.contains(key) || JMS_IBM_STRING_PROPERTIES.contains(key)) {
             return value.toString();
         }
-
-        // Unknown property: pass through as string with a warning so unknown keys surface clearly.
-        log.debug("Unknown JMS property '{}' with value type '{}'; passing through as String",
-                key, value == null ? "null" : value.getClass().getSimpleName());
-        return value == null ? null : value.toString();
+        if (JMS_SUPPORTED_TYPES.contains(value.getClass())) {
+            return value;
+        }
+        // user-defined property that is not a supported type 
+        //  convert to String for JMS compatibility
+        return value.toString();
     }
+
 
     private byte[] toByteArray(final String key, final Object value) {
         if (value instanceof byte[]) {
+            // if the connector is paired with ByteArrayConverter
+            //  or JsonConverter (with schemas.enable=true), we will 
+            //  have a byte[] we can use directly
             return (byte[]) value;
         }
         try {
-            return java.util.Base64.getDecoder().decode((String) value);
+            // We cannot distinguish between a string that came from 
+            //  StringConverter or SimpleHeaderConverter, so we are
+            //  assuming SimpleHeaderConverter behaviour 
+            // (as it is the default converter in Connect)
+
+            // if the connector is paired with StringConverter, we 
+            //   will have a string representation of the bytes
+            // return value.toString().getBytes();
+
+            // if the connector is paired with SimpleHeaderConverter, we 
+            //   will likely have a base64-encoded string representation 
+            //   of the byte array
+            return Base64.getDecoder().decode(value.toString());
         } catch (final IllegalArgumentException e) {
             throw new IllegalArgumentException(
                     String.format("Property '%s': value is not valid Base64: '%s'", key, value), e);
@@ -288,16 +329,38 @@ public class KafkaToJmsHeaderConverter {
     }
 
     private Integer toInteger(final String key, final Object value) {
+        if (value instanceof Integer) {
+            // if the connector is paired with ByteArrayConverter, JsonConverter (with
+            //   schemas.enable=true), IntegerConverter, or a typed header added directly,
+            //   we will have an Integer we can use directly
+            return (Integer) value;
+        }
+        if (value instanceof Number) {
+            // if the connector is paired with a numeric converter (ShortConverter,
+            //   LongConverter, FloatConverter, DoubleConverter) or JsonConverter
+            //   (with schemas.enable=true) with a non-Integer numeric type, we will
+            //   have a Number we can convert to int
+            return ((Number) value).intValue();
+        }
+        // if the connector is paired with SimpleHeaderConverter or StringConverter,
+        //   we will have a string representation of the integer
         try {
             return Integer.parseInt(value.toString());
-        } catch (final NumberFormatException | ClassCastException e) {
+        } catch (final NumberFormatException e) {
             throw new IllegalArgumentException(
                     String.format("Property '%s': cannot convert '%s' to Integer", key, value), e);
         }
     }
 
     private Boolean toBoolean(final String key, final Object value) {
-        final String s = (String) value;
+        if (value instanceof Boolean) {
+            // if the connector is paired with 
+            //  JsonConverter (with schemas.enable=true), we will 
+            //  have a boolean we can use directly
+            return (Boolean) value;
+        }
+
+        final String s = value.toString();
         if ("true".equalsIgnoreCase(s) || "1".equals(s)) return Boolean.TRUE;
         if ("false".equalsIgnoreCase(s) || "0".equals(s)) return Boolean.FALSE;
         throw new IllegalArgumentException(

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverter.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverter.java
@@ -132,7 +132,6 @@ public class KafkaToJmsHeaderConverter {
      * Only settable properties are included here.
      */
     private static final Set<String> JMS_IBM_INTEGER_PROPERTIES = new HashSet<>(Arrays.asList(
-            JmsConstants.JMS_IBM_CHARACTER_SET,
             JmsConstants.JMS_IBM_REPORT_EXCEPTION,
             JmsConstants.JMS_IBM_REPORT_EXPIRATION,
             JmsConstants.JMS_IBM_REPORT_COA,
@@ -236,12 +235,7 @@ public class KafkaToJmsHeaderConverter {
             if (value instanceof byte[]) {
                 message.setJMSCorrelationIDAsBytes((byte[]) value);
             } else {
-                String valueString = value.toString();
-                if (valueString.startsWith("ID:")) {
-                    valueString = valueString.substring(3);
-                }
-
-                message.setJMSCorrelationID(valueString);
+                message.setJMSCorrelationID(value.toString());
             }
             return;
         }

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverter.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverter.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+
+import com.ibm.msg.client.jms.JmsConstants;
+
+import org.apache.kafka.connect.header.Header;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.Set;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+/**
+ * Copies Kafka Connect headers to JMS message properties.
+ *
+ * Supports both legacy deployments where headers arrive as strings (for example from older
+ * MQ source connector versions) and typed headers produced by schema-aware connectors.
+ *
+ * See: https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=application-jms-message-object-properties
+ * See: https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=messages-jms-fields-properties-corresponding-mqmd-fields
+ * IBM MQ JMS message object properties
+ */
+public class KafkaToJmsHeaderConverter {
+    private static final Logger log = LoggerFactory.getLogger(KafkaToJmsHeaderConverter.class);
+    private static final HexFormat HEX_FORMAT = HexFormat.of();
+
+    private boolean mqmdWriteEnabled = false;
+
+    /**
+     * Sets whether MQMD write is enabled (mq.message.mqmd.write=true).
+     * @param enabled true if MQMD write is enabled
+     */
+    public void setMqmdWriteEnabled(final boolean enabled) {
+        this.mqmdWriteEnabled = enabled;
+    }
+
+    /**
+     * MQMD properties that require Integer type according to IBM MQ JMS specification.
+     *
+     * IMPORTANT NOTES about JMS Specification Compliance:
+     * - JMS_IBM_MQMD_Priority: Values outside 0-9 range violate JMS specification
+     * - JMS_IBM_MQMD_BackoutCount: Value can't be set by the connector. Any value set is ignored
+     * - JMS_IBM_MQMD_PutApplType: Requires WMQ_MQMD_MESSAGE_CONTEXT to be set to ALL context
+     * - These properties are IBM MQ extensions and may not be fully JMS-compliant
+     * - The connector passes values through; IBM MQ will validate/reject invalid values
+     */
+    private static final Set<String> MQMD_INTEGER_PROPERTIES = new HashSet<>(Arrays.asList(
+            JmsConstants.JMS_IBM_MQMD_REPORT,
+            JmsConstants.JMS_IBM_MQMD_MSGTYPE,
+            JmsConstants.JMS_IBM_MQMD_EXPIRY,
+            JmsConstants.JMS_IBM_MQMD_FEEDBACK,
+            JmsConstants.JMS_IBM_MQMD_ENCODING,
+            JmsConstants.JMS_IBM_MQMD_CODEDCHARSETID,
+            JmsConstants.JMS_IBM_MQMD_PRIORITY,
+            JmsConstants.JMS_IBM_MQMD_PERSISTENCE,
+            JmsConstants.JMS_IBM_MQMD_PUTAPPLTYPE,
+            JmsConstants.JMS_IBM_MQMD_MSGSEQNUMBER,
+            JmsConstants.JMS_IBM_MQMD_OFFSET,
+            JmsConstants.JMS_IBM_MQMD_MSGFLAGS,
+            JmsConstants.JMS_IBM_MQMD_ORIGINALLENGTH
+    ));
+
+    /**
+     * MQMD properties that require String type according to IBM MQ JMS specification.
+     *
+     * IMPORTANT: Some properties require WMQ_MQMD_MESSAGE_CONTEXT to be set on the Destination:
+     * - IDENTITY context (mq.message.mqmd.context=identity): UserIdentifier, AccountingToken, ApplIdentityData
+     * - ALL context (mq.message.mqmd.context=all): PutApplType, PutApplName, PutDate, PutTime, ApplOriginData
+     */
+    private static final Set<String> MQMD_STRING_PROPERTIES = new HashSet<>(Arrays.asList(
+            JmsConstants.JMS_IBM_MQMD_FORMAT,
+            JmsConstants.JMS_IBM_MQMD_REPLYTOQ,
+            JmsConstants.JMS_IBM_MQMD_REPLYTOQMGR,
+            JmsConstants.JMS_IBM_MQMD_USERIDENTIFIER,
+            JmsConstants.JMS_IBM_MQMD_APPLIDENTITYDATA,
+            JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME,
+            JmsConstants.JMS_IBM_MQMD_PUTDATE,
+            JmsConstants.JMS_IBM_MQMD_PUTTIME,
+            JmsConstants.JMS_IBM_MQMD_APPLORIGINDATA
+    ));
+
+    /**
+     * MQMD properties that require byte array type according to IBM MQ JMS specification.
+     *
+     * IMPORTANT: AccountingToken requires WMQ_MQMD_MESSAGE_CONTEXT to be set to IDENTITY or ALL context.
+     */
+    private static final Set<String> MQMD_BYTES_PROPERTIES = new HashSet<>(Arrays.asList(
+            JmsConstants.JMS_IBM_MQMD_CORRELID,
+            JmsConstants.JMS_IBM_MQMD_MSGID,
+            JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN,
+            JmsConstants.JMS_IBM_MQMD_GROUPID
+    ));
+
+    /**
+     * All MQMD properties (Integer, String, and byte[]) that can only be set when mq.message.mqmd.write=true.
+     * This is a combined set of all MQMD_INTEGER_PROPERTIES, MQMD_STRING_PROPERTIES, and MQMD_BYTES_PROPERTIES.
+     */
+    private static final Set<String> ALL_MQMD_PROPERTIES;
+
+    static {
+        ALL_MQMD_PROPERTIES = new HashSet<>();
+        ALL_MQMD_PROPERTIES.addAll(MQMD_INTEGER_PROPERTIES);
+        ALL_MQMD_PROPERTIES.addAll(MQMD_STRING_PROPERTIES);
+        ALL_MQMD_PROPERTIES.addAll(MQMD_BYTES_PROPERTIES);
+    }
+
+    /**
+     * JMS_IBM properties that require Integer type.
+     * These are standard JMS properties that map to MQMD fields and can be set by applications.
+     *
+     * Note: Many JMS_IBM properties are read-only (set by IBM MQ) and cannot be set by applications.
+     * Only settable properties are included here.
+     */
+    private static final Set<String> JMS_IBM_INTEGER_PROPERTIES = new HashSet<>(Arrays.asList(
+            JmsConstants.JMS_IBM_REPORT_EXCEPTION,
+            JmsConstants.JMS_IBM_REPORT_EXPIRATION,
+            JmsConstants.JMS_IBM_REPORT_COA,
+            JmsConstants.JMS_IBM_REPORT_COD,
+            JmsConstants.JMS_IBM_REPORT_PAN,
+            JmsConstants.JMS_IBM_REPORT_NAN,
+            JmsConstants.JMS_IBM_REPORT_PASS_MSG_ID,
+            JmsConstants.JMS_IBM_REPORT_PASS_CORREL_ID,
+            JmsConstants.JMS_IBM_REPORT_DISCARD_MSG,
+            JmsConstants.JMS_IBM_MSGTYPE,
+            JmsConstants.JMS_IBM_FEEDBACK,
+            JmsConstants.JMS_IBM_ENCODING,
+            JmsConstants.JMS_IBM_PUTAPPLTYPE
+    ));
+
+    /**
+     * JMS_IBM properties (non-MQMD) that require String type.
+     * Note: JMS_IBM_PutAppl, JMS_IBM_PutDate, JMS_IBM_PutTime are read-only and cannot be set.
+     */
+    @SuppressWarnings("unused")
+    private static final Set<String> JMS_IBM_STRING_PROPERTIES = new HashSet<>(Arrays.asList(
+            JmsConstants.JMS_IBM_FORMAT,
+            JmsConstants.JMS_IBM_CHARACTER_SET
+    ));
+
+    /**
+     * JMS_IBM properties that require Boolean type.
+     */
+    private static final Set<String> JMS_IBM_BOOLEAN_PROPERTIES = new HashSet<>(Arrays.asList(
+            JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP
+    ));
+
+    private static final Set<Object> MQMD_PROPERTIES_TO_IGNORE = new HashSet<>(Arrays.asList(
+            // Value can't be set by the connector. Any value set is ignored.
+            JmsConstants.JMS_IBM_MQMD_BACKOUTCOUNT
+    ));
+
+    /**
+     * Copies a Kafka Connect header to a JMS message property with type-correct conversion.
+     *
+     * The IBM MQ JMS specification requires specific Java types for MQMD and JMS_IBM
+     * properties. This method handles type coercion from both string-typed legacy headers
+     * and typed headers produced by schema-aware connectors.
+     *
+     * @param message the target JMS message
+     * @param header  the source Kafka Connect header
+     * @throws IllegalArgumentException if the property name is illegal or value conversion fails
+     */
+    public void copyHeaderToJmsProperty(final Message message, final Header header) {
+        final String key = header.key();
+        final Object value = header.value();
+
+        if (MQMD_PROPERTIES_TO_IGNORE.contains(key)) {
+            log.debug("Skipping read-only MQMD property '{}'", key);
+            return;
+        }
+
+        if (ALL_MQMD_PROPERTIES.contains(key) && !mqmdWriteEnabled) {
+            log.debug("Skipping MQMD property '{}': requires mq.message.mqmd.write=true", key);
+            return;
+        }
+
+        try {
+            if (value == null) {
+                // Set null value as property - JMS allows null values
+                // Source connector copies jms headers with null values to kafka headers.
+                message.setObjectProperty(key, null);
+                log.debug("Set property '{}' with null value", key);
+                return;
+            }
+
+            setJmsProperty(message, key, value);
+        } catch (final JMSException e) {
+            throw new IllegalArgumentException(
+                    String.format("Failed to set JMS property '%s' (type: %s, value: %s)",
+                            key, value == null ? "null" : value.getClass().getSimpleName(), value), e);
+        }
+    }
+
+    /**
+     * Sets the appropriate JMS property on the message, handling special-cased header keys
+     * (CorrelId, MsgId) before falling through to typed property conversion.
+     */
+    private void setJmsProperty(final Message message, final String key, final Object value)
+            throws JMSException {
+
+        if (JmsConstants.JMS_IBM_MQMD_CORRELID.equals(key)) {
+            message.setJMSCorrelationID(value.toString());
+            return;
+        }
+
+        if (JmsConstants.JMS_IBM_MQMD_MSGID.equals(key)) {
+            String hexString = value.toString();
+            // MQ automatically appends "ID:" to JMS_IBM_MQMD_MSGID, so strip it if present
+            if (hexString.startsWith("ID:")) {
+                hexString = hexString.substring(3);
+            }
+            final byte[] msgIdBytes = HEX_FORMAT.parseHex(hexString);
+            message.setObjectProperty(JmsConstants.JMS_IBM_MQMD_MSGID, msgIdBytes);
+            return;
+        }
+
+
+        final Object converted = convertToJmsType(key, value);
+        message.setObjectProperty(key, converted);
+        log.debug("Set property '{}' as {}: {}",
+                key,
+                converted == null ? null : converted.getClass().getSimpleName(),
+                converted);
+    }
+
+    /**
+     * Converts a Kafka header value to the Java type required by the IBM MQ JMS specification
+     * for the given property key.
+     *
+     * If the value is already the correct type (e.g., a typed header from a schema-aware
+     * connector), it is returned as-is. String values are coerced to the required type.
+     *
+     * @param key   the JMS property name
+     * @param value the raw value from the Kafka header
+     * @return the converted value, never {@code null}
+     * @throws IllegalArgumentException if conversion fails or the value is of an unexpected type
+     */
+    Object convertToJmsType(final String key, final Object value) {
+        if (MQMD_BYTES_PROPERTIES.contains(key)) {
+            return toByteArray(key, value);
+        }
+        if (MQMD_INTEGER_PROPERTIES.contains(key) || JMS_IBM_INTEGER_PROPERTIES.contains(key)) {
+            return toInteger(key, value);
+        }
+        if (JMS_IBM_BOOLEAN_PROPERTIES.contains(key)) {
+            return toBoolean(key, value);
+        }
+        if (MQMD_STRING_PROPERTIES.contains(key) || JMS_IBM_STRING_PROPERTIES.contains(key)) {
+            return value.toString();
+        }
+
+        // Unknown property: pass through as string with a warning so unknown keys surface clearly.
+        log.debug("Unknown JMS property '{}' with value type '{}'; passing through as String",
+                key, value == null ? "null" : value.getClass().getSimpleName());
+        return value == null ? null : value.toString();
+    }
+
+    private byte[] toByteArray(final String key, final Object value) {
+        if (value instanceof byte[]) {
+            return (byte[]) value;
+        }
+        try {
+            return java.util.Base64.getDecoder().decode((String) value);
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    String.format("Property '%s': value is not valid Base64: '%s'", key, value), e);
+        }
+    }
+
+    private Integer toInteger(final String key, final Object value) {
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (final NumberFormatException | ClassCastException e) {
+            throw new IllegalArgumentException(
+                    String.format("Property '%s': cannot convert '%s' to Integer", key, value), e);
+        }
+    }
+
+    private Boolean toBoolean(final String key, final Object value) {
+        final String s = (String) value;
+        if ("true".equalsIgnoreCase(s) || "1".equals(s)) return Boolean.TRUE;
+        if ("false".equalsIgnoreCase(s) || "0".equals(s)) return Boolean.FALSE;
+        throw new IllegalArgumentException(
+                String.format("Property '%s': cannot parse '%s' as Boolean (expected true/false/1/0)", key, value));
+    }
+}

--- a/src/test/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverterTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverterTest.java
@@ -61,7 +61,7 @@ public class KafkaToJmsHeaderConverterTest {
         // MQMD properties require mq.message.mqmd.write=true
         converter.setMqmdWriteEnabled(true);
 
-        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_PRIORITY, "5")
+        final Header header = new ConnectHeaders().addInt(JmsConstants.JMS_IBM_MQMD_PRIORITY, 5)
                 .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
 
         converter.copyHeaderToJmsProperty(message, header);
@@ -208,7 +208,7 @@ public class KafkaToJmsHeaderConverterTest {
         converter.copyHeaderToJmsProperty(message, header);
 
         // Verify the hex string was parsed correctly (without the "ID:" prefix)
-        final byte[] expectedBytes = java.util.HexFormat.of().parseHex(hexValue);
+        final byte[] expectedBytes = HexUtils.hexStringToBytes(hexValue);
         verify(message).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_MSGID), eq(expectedBytes));
     }
 
@@ -224,7 +224,7 @@ public class KafkaToJmsHeaderConverterTest {
         converter.copyHeaderToJmsProperty(message, header);
 
         // Verify the hex string was parsed correctly
-        final byte[] expectedBytes = java.util.HexFormat.of().parseHex(hexValue);
+        final byte[] expectedBytes = HexUtils.hexStringToBytes(hexValue);
         verify(message).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_MSGID), eq(expectedBytes));
     }
 
@@ -259,7 +259,7 @@ public class KafkaToJmsHeaderConverterTest {
 
         converter.copyHeaderToJmsProperty(message, header);
 
-        verify(message).setObjectProperty("priority", "5");
+        verify(message).setObjectProperty("priority", 5);
     }
 
     @Test
@@ -283,13 +283,13 @@ public class KafkaToJmsHeaderConverterTest {
 
 
     @Test
-    public void classifiesCharacterSetAsString() throws Exception {
+    public void classifiesCharacterSetAsInt() throws Exception {
         final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_CHARACTER_SET, "819")
                 .lastWithName(JmsConstants.JMS_IBM_CHARACTER_SET);
 
         converter.copyHeaderToJmsProperty(message, header);
 
-        verify(message).setObjectProperty(JmsConstants.JMS_IBM_CHARACTER_SET, "819");
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_CHARACTER_SET, 819);
     }
 
     @Test
@@ -369,45 +369,42 @@ public class KafkaToJmsHeaderConverterTest {
         // Boolean
         Header header = new ConnectHeaders().addBoolean("BoolProp", true).lastWithName("BoolProp");
         converter.copyHeaderToJmsProperty(message, header);
-        verify(message).setObjectProperty("BoolProp", Boolean.TRUE.toString());
+        verify(message).setObjectProperty("BoolProp", Boolean.TRUE);
 
         // Byte
         header = new ConnectHeaders().addByte("ByteProp", (byte) 127).lastWithName("ByteProp");
         converter.copyHeaderToJmsProperty(message, header);
-        verify(message).setObjectProperty("ByteProp", "127");
+        verify(message).setObjectProperty("ByteProp", (byte) 127);
 
         // Short
         header = new ConnectHeaders().addShort("ShortProp", (short) 32000).lastWithName("ShortProp");
         converter.copyHeaderToJmsProperty(message, header);
-        verify(message).setObjectProperty("ShortProp", "32000");
+        verify(message).setObjectProperty("ShortProp", (short) 32000);
 
         // Integer
         header = new ConnectHeaders().addInt("IntProp", 42).lastWithName("IntProp");
         converter.copyHeaderToJmsProperty(message, header);
-        verify(message).setObjectProperty("IntProp", "42");
+        verify(message).setObjectProperty("IntProp", 42);
 
         // Long
         header = new ConnectHeaders().addLong("LongProp", 1234567890L).lastWithName("LongProp");
         converter.copyHeaderToJmsProperty(message, header);
-        verify(message).setObjectProperty("LongProp", "1234567890");
+        verify(message).setObjectProperty("LongProp", 1234567890L);
 
         // Float
         header = new ConnectHeaders().addFloat("FloatProp", 3.14f).lastWithName("FloatProp");
         converter.copyHeaderToJmsProperty(message, header);
-        verify(message).setObjectProperty("FloatProp", "3.14");
+        verify(message).setObjectProperty("FloatProp", 3.14f);
 
         // Double
         header = new ConnectHeaders().addDouble("DoubleProp", 2.71828).lastWithName("DoubleProp");
         converter.copyHeaderToJmsProperty(message, header);
-        verify(message).setObjectProperty("DoubleProp", "2.71828");
+        verify(message).setObjectProperty("DoubleProp", 2.71828);
 
         // String
         header = new ConnectHeaders().addString("StringProp", "test").lastWithName("StringProp");
         converter.copyHeaderToJmsProperty(message, header);
         verify(message).setObjectProperty("StringProp", "test");
-
-        // Note: byte[] for non-MQMD properties are converted to String by source connector
-        // Only MQMD byte[] properties are preserved as byte[]
     }
 
     @Test
@@ -431,8 +428,8 @@ public class KafkaToJmsHeaderConverterTest {
     public void testInvalidIntegerStringIsSkipped() throws Exception {
         // Test that invalid integer strings are skipped
 
-        final Header header = new ConnectHeaders().addString("JMS_IBM_MQMD_Priority", "not-a-number")
-                .lastWithName("JMS_IBM_MQMD_Priority");
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_PRIORITY, "not-a-number")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
 
         // Should not throw exception, invalid value is skipped
         converter.copyHeaderToJmsProperty(message, header);
@@ -442,8 +439,8 @@ public class KafkaToJmsHeaderConverterTest {
     public void testInvalidIntegerTypeIsSkipped() throws Exception {
         // Test that incompatible types for integer properties are skipped
 
-        final Header header = new ConnectHeaders().add("JMS_IBM_MQMD_Priority", new Object(), null)
-                .lastWithName("JMS_IBM_MQMD_Priority");
+        final Header header = new ConnectHeaders().add(JmsConstants.JMS_IBM_MQMD_PRIORITY, new Object(), null)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
 
         // Should not throw exception, invalid value is skipped
         converter.copyHeaderToJmsProperty(message, header);
@@ -453,8 +450,8 @@ public class KafkaToJmsHeaderConverterTest {
     public void testInvalidBooleanStringIsSkipped() throws Exception {
         // Test that invalid boolean strings are skipped
 
-        final Header header = new ConnectHeaders().addString("JMS_IBM_Report_Exception", "not-a-boolean")
-                .lastWithName("JMS_IBM_Report_Exception");
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_REPORT_EXCEPTION, "not-a-boolean")
+                .lastWithName(JmsConstants.JMS_IBM_REPORT_EXCEPTION);
 
         // Should not throw exception, invalid value is skipped
         converter.copyHeaderToJmsProperty(message, header);
@@ -464,8 +461,8 @@ public class KafkaToJmsHeaderConverterTest {
     public void testInvalidBooleanTypeIsSkipped() throws Exception {
         // Test that incompatible types for boolean properties are skipped
 
-        final Header header = new ConnectHeaders().add("JMS_IBM_Report_Exception", new Object(), null)
-                .lastWithName("JMS_IBM_Report_Exception");
+        final Header header = new ConnectHeaders().add(JmsConstants.JMS_IBM_REPORT_EXCEPTION, new Object(), null)
+                .lastWithName(JmsConstants.JMS_IBM_REPORT_EXCEPTION);
 
         // Should not throw exception, invalid value is skipped
         converter.copyHeaderToJmsProperty(message, header);
@@ -473,7 +470,6 @@ public class KafkaToJmsHeaderConverterTest {
 
     @Test
     public void copiesJmsDeliveryModeAsString() throws Exception {
-        // Test that JMS_DELIVERY_MODE uses dedicated setter with String value
         final Header header = new ConnectHeaders().addString(JmsConstants.JMS_DELIVERY_MODE, "2")
                 .lastWithName(JmsConstants.JMS_DELIVERY_MODE);
 
@@ -487,7 +483,6 @@ public class KafkaToJmsHeaderConverterTest {
 
     @Test
     public void copiesJmsExpirationAsString() throws Exception {
-        // Test that JMS_EXPIRATION uses dedicated setter with String value
         final Header header = new ConnectHeaders().addString(JmsConstants.JMS_EXPIRATION, "60000")
                 .lastWithName(JmsConstants.JMS_EXPIRATION);
 

--- a/src/test/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverterTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverterTest.java
@@ -1,0 +1,531 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import javax.jms.Message;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.ibm.msg.client.jms.JmsConstants;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KafkaToJmsHeaderConverterTest {
+
+    @Mock
+    private Message message;
+
+    @InjectMocks
+    private KafkaToJmsHeaderConverter converter;
+
+
+    @Test
+    public void copiesLegacyStringMqmdIntegerHeader() throws Exception {
+        // MQMD properties require mq.message.mqmd.write=true
+        converter.setMqmdWriteEnabled(true);
+
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_PRIORITY, "5")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_MQMD_PRIORITY, 5);
+    }
+
+    @Test
+    public void copiesTypedMqmdIntegerHeader() throws Exception {
+        // MQMD properties require mq.message.mqmd.write=true
+        converter.setMqmdWriteEnabled(true);
+
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_PRIORITY, "5")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_MQMD_PRIORITY, 5);
+    }
+
+    @Test
+    public void skipsInvalidLegacyMqmdIntegerHeader() throws Exception {
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_PRIORITY, "abc")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
+
+        // Should not throw exception, invalid value is skipped
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+    @Test
+    public void coercesIbmBooleanHeaderFromString() throws Exception {
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP, "true")
+                .lastWithName(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP, true);
+    }
+
+    @Test
+    public void coercesIbmBooleanHeaderFromStringOne() throws Exception {
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP, "1")
+                .lastWithName(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP, true);
+    }
+
+    @Test
+    public void copiesMqmdStringHeader() throws Exception {
+        // MQMD properties require mq.message.mqmd.write=true
+        converter.setMqmdWriteEnabled(true);
+
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_FORMAT, "MQSTR")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_FORMAT);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_MQMD_FORMAT, "MQSTR");
+    }
+
+    @Test
+    public void skipsMqmdMsgIdByteArrayWhenMqmdWriteDisabled() throws Exception {
+        converter.setMqmdWriteEnabled(false);
+
+        final String value = "ID:414141407061756C745639344C545320EBC32F6A01A00740";
+        final Header header = new ConnectHeaders().add(JmsConstants.JMS_IBM_MQMD_MSGID, value, Schema.STRING_SCHEMA)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_MSGID);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify setObjectProperty was NOT called
+        verify(message, never()).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_MSGID), any());
+    }
+
+    @Test
+    public void skipsMqmdCorrelIdByteArrayWhenMqmdWriteDisabled() throws Exception {
+        converter.setMqmdWriteEnabled(false);
+
+        final String value = "correlId";
+        final Header header = new ConnectHeaders().add(JmsConstants.JMS_IBM_MQMD_CORRELID, value, Schema.STRING_SCHEMA)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_CORRELID);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify setObjectProperty was NOT called
+        verify(message, never()).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_CORRELID), any());
+    }
+
+    @Test
+    public void skipsMqmdGroupIdByteArrayWhenMqmdWriteDisabled() throws Exception {
+        // MQMD_GROUPID byte[] should be skipped when mq.message.mqmd.write=false (default)
+        converter.setMqmdWriteEnabled(false);
+
+        final byte[] value = new byte[] {0x01, 0x02, 0x03};
+        final Header header = new ConnectHeaders().add(JmsConstants.JMS_IBM_MQMD_GROUPID, value, Schema.OPTIONAL_BYTES_SCHEMA)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_GROUPID);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify setObjectProperty was NOT called
+        verify(message, never()).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_GROUPID), any());
+    }
+
+    @Test
+    public void skipsMqmdAccountingTokenByteArrayWhenMqmdWriteDisabled() throws Exception {
+        // MQMD_ACCOUNTINGTOKEN byte[] should be skipped when mq.message.mqmd.write=false (default)
+        converter.setMqmdWriteEnabled(false);
+
+        final byte[] value = new byte[] {0x01, 0x02, 0x03};
+        final Header header = new ConnectHeaders().add(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN, value, Schema.OPTIONAL_BYTES_SCHEMA)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify setObjectProperty was NOT called
+        verify(message, never()).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN), any());
+    }
+
+    @Test
+    public void skipsMqmdIntegerPropertyWhenMqmdWriteDisabled() throws Exception {
+        // MQMD Integer properties should be skipped when mq.message.mqmd.write=false (default)
+        converter.setMqmdWriteEnabled(false);
+
+        final Header header = new ConnectHeaders().addInt(JmsConstants.JMS_IBM_MQMD_PRIORITY, 5)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify setObjectProperty was NOT called
+        verify(message, never()).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_PRIORITY), any());
+    }
+
+    @Test
+    public void skipsMqmdStringPropertyWhenMqmdWriteDisabled() throws Exception {
+        // MQMD String properties should be skipped when mq.message.mqmd.write=false (default)
+        converter.setMqmdWriteEnabled(false);
+
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_FORMAT, "MQSTR")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_FORMAT);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify setObjectProperty was NOT called
+        verify(message, never()).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_FORMAT), any());
+    }
+    @Test
+    public void setsMqmdMsgIdWithIdPrefix() throws Exception {
+        // Test that MSGID with "ID:" prefix is handled correctly
+        converter.setMqmdWriteEnabled(true);
+
+        final String hexValue = "414d5120514d312020202020202020205e7e5f6601c04a28";
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_MSGID, "ID:" + hexValue)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_MSGID);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify the hex string was parsed correctly (without the "ID:" prefix)
+        final byte[] expectedBytes = java.util.HexFormat.of().parseHex(hexValue);
+        verify(message).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_MSGID), eq(expectedBytes));
+    }
+
+    @Test
+    public void setsMqmdMsgIdWithoutIdPrefix() throws Exception {
+        // Test that MSGID without "ID:" prefix is handled correctly
+        converter.setMqmdWriteEnabled(true);
+
+        final String hexValue = "414d5120514d312020202020202020205e7e5f6601c04a28";
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_MSGID, hexValue)
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_MSGID);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify the hex string was parsed correctly
+        final byte[] expectedBytes = java.util.HexFormat.of().parseHex(hexValue);
+        verify(message).setObjectProperty(eq(JmsConstants.JMS_IBM_MQMD_MSGID), eq(expectedBytes));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionForInvalidMsgIdHex() throws Exception {
+        // Test that invalid hex string throws an exception
+        converter.setMqmdWriteEnabled(true);
+
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_MSGID, "ID:INVALID_HEX")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_MSGID);
+
+        // Should throw IllegalArgumentException due to invalid hex format
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionForByteArrayToStringMsgId() throws Exception {
+        // Old Source Connector sends byte arrays as toString() - should throw exception
+        converter.setMqmdWriteEnabled(true);
+
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_MSGID, "[B@42969b24")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_MSGID);
+
+        // Should throw IllegalArgumentException due to invalid hex format
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+
+    @Test
+    public void copiesTypedCustomIntegerHeader() throws Exception {
+        final Header header = new ConnectHeaders().addInt("priority", 5).lastWithName("priority");
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty("priority", "5");
+    }
+
+    @Test
+    public void copiesLegacyStringCustomHeader() throws Exception {
+        final Header header = new ConnectHeaders().addString("customHeader", "headerValue")
+                .lastWithName("customHeader");
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty("customHeader", "headerValue");
+    }
+
+    @Test
+    public void copiesLegacyStringNumericCustomHeader() throws Exception {
+        final Header header = new ConnectHeaders().addString("volume", "11").lastWithName("volume");
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty("volume", "11");
+    }
+
+
+    @Test
+    public void classifiesCharacterSetAsString() throws Exception {
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_CHARACTER_SET, "819")
+                .lastWithName(JmsConstants.JMS_IBM_CHARACTER_SET);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_CHARACTER_SET, "819");
+    }
+
+    @Test
+    public void copiesJmsIbmReportException() throws Exception {
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_REPORT_EXCEPTION, "1")
+                .lastWithName(JmsConstants.JMS_IBM_REPORT_EXCEPTION);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_REPORT_EXCEPTION, 1);
+    }
+
+    @Test
+    public void integerParseFailureSkipsProperty() throws Exception {
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_MQMD_PRIORITY, "abc")
+                .lastWithName(JmsConstants.JMS_IBM_MQMD_PRIORITY);
+
+        // Should not throw exception, invalid value is skipped
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void booleanParseFailureSkipsProperty() throws Exception {
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP, "invalid")
+                .lastWithName(JmsConstants.JMS_IBM_LAST_MSG_IN_GROUP);
+
+        // Should throw IllegalArgumentException for invalid boolean value
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+
+    @Test
+    public void setsNullHeaderValue() throws Exception {
+        // Test that null values are set as properties (JMS allows null values)
+        final Header header = new ConnectHeaders().add("nullHeader", null, Schema.OPTIONAL_STRING_SCHEMA)
+                .lastWithName("nullHeader");
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify that null value is set as a property
+        verify(message).setObjectProperty("nullHeader", null);
+    }
+
+    @Test
+    public void testNullIntegerPropertyIsSet() throws Exception {
+        // Test that null values for integer properties like JMS_IBM_MSGTYPE
+        // are set correctly without throwing JMSException
+
+        final Header header = new ConnectHeaders().add(JmsConstants.JMS_IBM_MSGTYPE, null, Schema.OPTIONAL_INT32_SCHEMA)
+                .lastWithName(JmsConstants.JMS_IBM_MSGTYPE);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Verify that null value is set as a property (JMS allows null for Object properties)
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_MSGTYPE, null);
+    }
+
+    @Test
+    public void testUnsupportedTypeConvertedToString() throws Exception {
+        // Test that unsupported types (like Date, Struct, etc.) are converted to String
+        // to avoid JMSException from setObjectProperty()
+
+        final java.util.Date dateValue = new java.util.Date(1234567890000L);
+        final Header header = new ConnectHeaders().add("DateProp", dateValue, null)
+                .lastWithName("DateProp");
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Should convert Date to String
+        verify(message).setObjectProperty("DateProp", dateValue.toString());
+    }
+
+    @Test
+    public void testJmsSupportedTypesPreserved() throws Exception {
+        // Test that JMS-supported types are preserved as-is for custom properties
+
+        // Boolean
+        Header header = new ConnectHeaders().addBoolean("BoolProp", true).lastWithName("BoolProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("BoolProp", Boolean.TRUE.toString());
+
+        // Byte
+        header = new ConnectHeaders().addByte("ByteProp", (byte) 127).lastWithName("ByteProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("ByteProp", "127");
+
+        // Short
+        header = new ConnectHeaders().addShort("ShortProp", (short) 32000).lastWithName("ShortProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("ShortProp", "32000");
+
+        // Integer
+        header = new ConnectHeaders().addInt("IntProp", 42).lastWithName("IntProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("IntProp", "42");
+
+        // Long
+        header = new ConnectHeaders().addLong("LongProp", 1234567890L).lastWithName("LongProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("LongProp", "1234567890");
+
+        // Float
+        header = new ConnectHeaders().addFloat("FloatProp", 3.14f).lastWithName("FloatProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("FloatProp", "3.14");
+
+        // Double
+        header = new ConnectHeaders().addDouble("DoubleProp", 2.71828).lastWithName("DoubleProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("DoubleProp", "2.71828");
+
+        // String
+        header = new ConnectHeaders().addString("StringProp", "test").lastWithName("StringProp");
+        converter.copyHeaderToJmsProperty(message, header);
+        verify(message).setObjectProperty("StringProp", "test");
+
+        // Note: byte[] for non-MQMD properties are converted to String by source connector
+        // Only MQMD byte[] properties are preserved as byte[]
+    }
+
+    @Test
+    public void testComplexTypeConvertedToString() throws Exception {
+        // Test that complex types like Map are converted to String
+
+        final java.util.Map<String, Object> mapValue = new java.util.HashMap<>();
+        mapValue.put("key1", "value1");
+        mapValue.put("key2", 42);
+
+        final Header header = new ConnectHeaders().add("MapProp", mapValue, null)
+                .lastWithName("MapProp");
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        // Should convert Map to String
+        verify(message).setObjectProperty("MapProp", mapValue.toString());
+    }
+
+    @Test
+    public void testInvalidIntegerStringIsSkipped() throws Exception {
+        // Test that invalid integer strings are skipped
+
+        final Header header = new ConnectHeaders().addString("JMS_IBM_MQMD_Priority", "not-a-number")
+                .lastWithName("JMS_IBM_MQMD_Priority");
+
+        // Should not throw exception, invalid value is skipped
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+    @Test
+    public void testInvalidIntegerTypeIsSkipped() throws Exception {
+        // Test that incompatible types for integer properties are skipped
+
+        final Header header = new ConnectHeaders().add("JMS_IBM_MQMD_Priority", new Object(), null)
+                .lastWithName("JMS_IBM_MQMD_Priority");
+
+        // Should not throw exception, invalid value is skipped
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidBooleanStringIsSkipped() throws Exception {
+        // Test that invalid boolean strings are skipped
+
+        final Header header = new ConnectHeaders().addString("JMS_IBM_Report_Exception", "not-a-boolean")
+                .lastWithName("JMS_IBM_Report_Exception");
+
+        // Should not throw exception, invalid value is skipped
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidBooleanTypeIsSkipped() throws Exception {
+        // Test that incompatible types for boolean properties are skipped
+
+        final Header header = new ConnectHeaders().add("JMS_IBM_Report_Exception", new Object(), null)
+                .lastWithName("JMS_IBM_Report_Exception");
+
+        // Should not throw exception, invalid value is skipped
+        converter.copyHeaderToJmsProperty(message, header);
+    }
+
+    @Test
+    public void copiesJmsDeliveryModeAsString() throws Exception {
+        // Test that JMS_DELIVERY_MODE uses dedicated setter with String value
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_DELIVERY_MODE, "2")
+                .lastWithName(JmsConstants.JMS_DELIVERY_MODE);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(
+            "JMSDeliveryMode",
+            "2"
+        );
+    }
+
+    @Test
+    public void copiesJmsExpirationAsString() throws Exception {
+        // Test that JMS_EXPIRATION uses dedicated setter with String value
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_EXPIRATION, "60000")
+                .lastWithName(JmsConstants.JMS_EXPIRATION);
+
+        converter.copyHeaderToJmsProperty(message, header);
+
+        verify(message).setObjectProperty(
+            "JMSExpiration",
+            "60000"
+        );
+    }
+
+    @Test
+    public void skipsInvalidJmsDeliveryMode() throws Exception {
+        // Test that invalid JMS_DELIVERY_MODE value is handled gracefully
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_DELIVERY_MODE, "invalid")
+                .lastWithName(JmsConstants.JMS_DELIVERY_MODE);
+
+        // Should not throw exception, invalid value causes NumberFormatException
+        // which is caught and handled by the dedicated setter
+        try {
+            converter.copyHeaderToJmsProperty(message, header);
+        } catch (final NumberFormatException e) {
+            // Expected - invalid integer string
+        }
+    }
+
+    @Test
+    public void skipsInvalidJmsExpiration() throws Exception {
+        // Test that invalid JMS_EXPIRATION value is handled gracefully
+        final Header header = new ConnectHeaders().addString(JmsConstants.JMS_EXPIRATION, "invalid")
+                .lastWithName(JmsConstants.JMS_EXPIRATION);
+
+        // Should not throw exception, invalid value causes NumberFormatException
+        // which is caught and handled by the dedicated setter
+        try {
+            converter.copyHeaderToJmsProperty(message, header);
+        } catch (final NumberFormatException e) {
+            // Expected - invalid long string
+        }
+    }
+}

--- a/src/test/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverterTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/mqsink/builders/KafkaToJmsHeaderConverterTest.java
@@ -289,7 +289,7 @@ public class KafkaToJmsHeaderConverterTest {
 
         converter.copyHeaderToJmsProperty(message, header);
 
-        verify(message).setObjectProperty(JmsConstants.JMS_IBM_CHARACTER_SET, 819);
+        verify(message).setObjectProperty(JmsConstants.JMS_IBM_CHARACTER_SET, "819");
     }
 
     @Test


### PR DESCRIPTION
# Description

A client has encountered a reproducible connector error when attempting to pass native MQMD headers end-to-end through a Kafka pipeline using the official open-source connector infrastructure.

The connector framework fails with a _DetailedMessageFormatException_ because it forces all incoming Kafka headers into Java Strings instead of setting them correctly for the underlying IBM MQ JMS API.

Client EnvironmentPipeline Topology: 

IBM MQ Queue -> MQ Source Connector -> Kafka Topic (Confluent Platform) -> IBM MQ Sink Connector -> Destination MQ Queue

Key Sink Configurations Enabled:
```
mq.message.mqmd.write: "true"
mq.kafka.headers.copy.to.jms.properties: "true"
```
When `mq.kafka.headers.copy.to.jms.properties `is true, connector iterates through incoming Kafka headers and indiscriminately attempts to inject them into the outbound message via .setStringProperty(). Because `mq.message.mqmd.write `is also true, the underlying IBM MQ JMS driver intercepts target properties starting with JMS_IBM_MQMD_. The driver strictly enforces that structural parameters like JMS_IBM_MQMD_Priority or JMS_IBM_MQMD_Expiry must be primitive integers. Passing a string format causes the JMS driver to throw error JMSCC0051.

Stack Trace Snippet:

```
Caused by: org.apache.kafka.connect.errors.ConnectException: Failed to set header
    at com.ibm.eventstreams.connect.mqsink.builders.BaseMessageBuilder.fromSinkRecord(BaseMessageBuilder.java:221)
...
Caused by: com.ibm.msg.client.jms.DetailedMessageFormatException: JMSCC0051: The property 'JMS_IBM_MQMD_Priority' should be set using type 'java.lang.Integer', not 'java.lang.String'.
JMS_IBM properties may only be set using a specific variable type.
Correct application code to use the required variable type when setting this JMS_IBM property.
    at com.ibm.msg.client.jms.internal.JmsMessageImpl.setStringProperty(JmsMessageImpl.java:1982)
    at com.ibm.eventstreams.connect.mqsink.builders.BaseMessageBuilder.fromSinkRecord(BaseMessageBuilder.java:219)

```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## How Has This Been Tested?
- [x] Integration Test

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules