### PR TITLE
fix: custom retry backoff assignment

### DIFF
--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskExceptionHandlingIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/MQSinkTaskExceptionHandlingIT.java
@@ -254,4 +254,32 @@ public class MQSinkTaskExceptionHandlingIT extends AbstractJMSContextIT {
         verify(connectTaskSpy.getContext(), times(1)).timeout(connectTaskSpy.retryBackoffMs);
         verify(connectTaskSpy, times(0)).stop();
     }
+
+    @Test
+    public void testRetryBackoffTimeoutIsSetCorrectly()
+            throws JsonProcessingException, JMSRuntimeException, JMSException {
+        // Test with custom retry backoff value
+        final Map<String, String> connectorConfigProps = getExactlyOnceConnectionDetails();
+        connectorConfigProps.put(MQSinkConfig.CONFIG_NAME_MQ_RETRY_BACKOFF_MS, "30000");
+
+        final MQSinkTask connectTaskSpy = spy(getMqSinkTask(connectorConfigProps));
+
+        final JMSWorker jmsWorkerSpy = spy(JMSWorker.class);
+        // Simulate MQRC_NOT_AUTHORIZED (2035) - the error from customer logs
+        final MQException authException = new MQException(1, 2035, getClass());
+        when(connectTaskSpy.newJMSWorker()).thenReturn(jmsWorkerSpy);
+        doThrow(new RetriableException("Authorization failed", authException))
+                .when(jmsWorkerSpy)
+                .readFromStateQueue();
+
+        connectTaskSpy.start(connectorConfigProps);
+        final List<SinkRecord> sinkRecords = createSinkRecords(1);
+
+        assertThrows(RetriableException.class, () -> {
+            connectTaskSpy.put(sinkRecords);
+        });
+
+        // Verify that context.timeout() was called with the configured backoff value (30000ms)
+        verify(connectTaskSpy.getContext(), times(1)).timeout(30000L);
+    }
 }

--- a/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkTask.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsink/MQSinkTask.java
@@ -241,7 +241,7 @@ public class MQSinkTask extends SinkTask {
      */
     private void setRetryBackoff(final AbstractConfig config) {
         // check if a custom retry time is provided
-        final Long retryBackoffMs = config.getLong(MQSinkConfig.CONFIG_NAME_MQ_RETRY_BACKOFF_MS);
+        retryBackoffMs = config.getLong(MQSinkConfig.CONFIG_NAME_MQ_RETRY_BACKOFF_MS);
         log.debug("Setting retry backoff {}", retryBackoffMs);
     }
 


### PR DESCRIPTION
# Description

The setRetryBackoff() method was reading the custom retry backoff configuration value but assigning it to a local variable instead of the instance field. This caused the connector to always use the default retry backoff time (60000ms) instead of the user-configured value when handling retriable exceptions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] E2E
- [ ] Unit Test
- [ ] Integration Test

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules