### PR TITLE
feat: add IT for MQMD header handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.20.2</version>
+      <version>1.21.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MqmdStringKafkaHeadersIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/builders/MqmdStringKafkaHeadersIT.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.builders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Test;
+
+import com.ibm.eventstreams.connect.mqsink.AbstractJMSContextIT;
+import com.ibm.eventstreams.connect.mqsink.util.MqmdHeaderSamples;
+import com.ibm.eventstreams.connect.mqsink.util.MqmdHeaderSamples.CustomProperty;
+import com.ibm.eventstreams.connect.mqsink.util.MqmdHeaderSamples.IntegerProperty;
+import com.ibm.eventstreams.connect.mqsink.util.MqmdHeaderSamples.StringProperty;
+
+/**
+ * Reproduces the client issue: MQ source emits MQMD headers as strings; {@link BaseMessageBuilder}
+ * copies them with {@code setStringProperty}, which IBM MQ rejects for integer MQMD fields
+ * (JMSCC0051).
+ */
+public class MqmdStringKafkaHeadersIT extends AbstractJMSContextIT {
+
+    private static final String BODY = "mqmd header issue repro";
+
+    @Test
+    public void ibmMqRejectsStringSetterForIntegerMqmdProperties() throws Exception {
+        for (final IntegerProperty sample : MqmdHeaderSamples.integerMqmdProperties()) {
+            final Message message = getJmsContext().createTextMessage(BODY);
+
+            try {
+                message.setStringProperty(sample.key(), sample.stringValue());
+                fail("IBM MQ should reject setStringProperty for " + sample.key());
+            } catch (final JMSException e) {
+                assertTrue("Expected JMSCC0051 for " + sample.key() + ": " + e.getMessage(),
+                        containsJmscc0051(e));
+            }
+
+            message.setIntProperty(sample.key(), sample.intValue());
+            assertEquals("Wrong int value for " + sample.key(),
+                    sample.intValue(), message.getIntProperty(sample.key()));
+        }
+    }
+
+    @Test
+    public void ibmMqAcceptsStringSetterForStringMqmdProperties() throws Exception {
+        for (final StringProperty sample : MqmdHeaderSamples.stringMqmdProperties()) {
+            final Message message = getJmsContext().createTextMessage(BODY);
+            message.setStringProperty(sample.key(), sample.value());
+            assertEquals("Wrong string value for " + sample.key(),
+                    sample.value(), message.getStringProperty(sample.key()));
+        }
+    }
+
+    @Test
+    public void currentBuilderFailsOnEachIntegerMqmdHeader() throws Exception {
+        final DefaultMessageBuilder builder = builderWithHeaderCopyEnabled();
+
+        for (final IntegerProperty sample : MqmdHeaderSamples.integerMqmdProperties()) {
+            try {
+                builder.fromSinkRecord(getJmsContext(), sinkRecord(sample.asSingleHeader()));
+                fail("Expected ConnectException for string header " + sample.key());
+            } catch (final ConnectException e) {
+                assertTrue("Expected JMSCC0051 for " + sample.key() + ": " + e.getMessage(),
+                        containsJmscc0051(e));
+            }
+        }
+    }
+
+    @Test
+    public void currentBuilderSucceedsOnStringMqmdHeaders() throws Exception {
+        final DefaultMessageBuilder builder = builderWithHeaderCopyEnabled();
+
+        for (final StringProperty sample : MqmdHeaderSamples.stringMqmdProperties()) {
+            final Message message = builder.fromSinkRecord(getJmsContext(), sinkRecord(sample.asSingleHeader()));
+            assertEquals(sample.value(), message.getStringProperty(sample.key()));
+        }
+    }
+
+    @Test
+    public void currentBuilderSucceedsOnCustomStringHeaders() throws Exception {
+        final DefaultMessageBuilder builder = builderWithHeaderCopyEnabled();
+
+        for (final CustomProperty sample : MqmdHeaderSamples.customProperties()) {
+            final Message message = builder.fromSinkRecord(getJmsContext(), sinkRecord(sample.asSingleHeader()));
+            assertEquals(sample.value(), message.getStringProperty(sample.key()));
+        }
+    }
+
+    @Test
+    public void currentBuilderFailsOnClientMqmdHeaderSet() throws Exception {
+        final DefaultMessageBuilder builder = builderWithHeaderCopyEnabled();
+
+        try {
+            builder.fromSinkRecord(getJmsContext(), sinkRecord(MqmdHeaderSamples.clientMqmdPipelineAsStrings()));
+            fail("Expected ConnectException when copying full client MQMD string header set");
+        } catch (final ConnectException e) {
+            assertTrue("Expected JMSCC0051 in cause chain: " + e.getMessage(), containsJmscc0051(e));
+        }
+    }
+
+    private static DefaultMessageBuilder builderWithHeaderCopyEnabled() {
+        final DefaultMessageBuilder builder = new DefaultMessageBuilder();
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.kafka.headers.copy.to.jms.properties", "true");
+        props.put("mq.message.mqmd.writemq.message.mqmd.write", "true");
+        builder.configure(props);
+        return builder;
+    }
+
+    private static SinkRecord sinkRecord(final ConnectHeaders headers) {
+        return new SinkRecord(
+                TOPIC, PARTITION,
+                Schema.STRING_SCHEMA, "key",
+                Schema.STRING_SCHEMA, BODY,
+                0L, null, TimestampType.NO_TIMESTAMP_TYPE,
+                headers);
+    }
+
+    private static boolean containsJmscc0051(final Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            final String message = current.getMessage();
+            if (message != null && (message.contains("JMSCC0051")
+                    || message.contains("should be set using type 'java.lang.Integer'"))) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsink/util/MqmdHeaderSamples.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsink/util/MqmdHeaderSamples.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsink.util;
+
+import org.apache.kafka.connect.header.ConnectHeaders;
+
+import com.ibm.msg.client.jms.JmsConstants;
+
+/**
+ * MQMD header samples from the client issue: Kafka string values as produced by MQ source.
+ */
+public final class MqmdHeaderSamples {
+
+    private MqmdHeaderSamples() {
+    }
+
+    /** IBM MQ integer MQMD field copied as a string Kafka header. */
+    public static final class IntegerProperty {
+        private final String key;
+        private final String stringValue;
+        private final int intValue;
+
+        public IntegerProperty(final String key, final String stringValue, final int intValue) {
+            this.key = key;
+            this.stringValue = stringValue;
+            this.intValue = intValue;
+        }
+
+        public String key() {
+            return key;
+        }
+
+        public String stringValue() {
+            return stringValue;
+        }
+
+        public int intValue() {
+            return intValue;
+        }
+
+        public ConnectHeaders asSingleHeader() {
+            final ConnectHeaders headers = new ConnectHeaders();
+            headers.addString(key, stringValue);
+            return headers;
+        }
+    }
+
+    /** IBM MQ string MQMD field copied as a string Kafka header. */
+    public static final class StringProperty {
+        private final String key;
+        private final String value;
+
+        public StringProperty(final String key, final String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String key() {
+            return key;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public ConnectHeaders asSingleHeader() {
+            final ConnectHeaders headers = new ConnectHeaders();
+            headers.addString(key, value);
+            return headers;
+        }
+    }
+
+    /** Custom (non-MQMD) business header copied as a string Kafka header. */
+    public static final class CustomProperty {
+        private final String key;
+        private final String value;
+
+        public CustomProperty(final String key, final String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String key() {
+            return key;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public ConnectHeaders asSingleHeader() {
+            final ConnectHeaders headers = new ConnectHeaders();
+            headers.addString(key, value);
+            return headers;
+        }
+    }
+
+    public static IntegerProperty[] integerMqmdProperties() {
+        return new IntegerProperty[] {
+                new IntegerProperty(JmsConstants.JMS_IBM_MQMD_PRIORITY, "2", 2),
+                new IntegerProperty(JmsConstants.JMS_IBM_MQMD_CODEDCHARSETID, "437", 437),
+                new IntegerProperty(JmsConstants.JMS_IBM_ENCODING, "546", 546),
+                new IntegerProperty(JmsConstants.JMS_IBM_MQMD_EXPIRY, "-1", -1),
+                new IntegerProperty(JmsConstants.JMS_IBM_MQMD_MSGSEQNUMBER, "1", 1),
+                new IntegerProperty(JmsConstants.JMS_IBM_MQMD_MSGFLAGS, "0", 0),
+                new IntegerProperty(JmsConstants.JMS_IBM_MQMD_OFFSET, "0", 0),
+                new IntegerProperty(JmsConstants.JMS_IBM_MSGTYPE, "1", 1),
+                new IntegerProperty(JmsConstants.JMS_IBM_PUTAPPLTYPE, "11", 11),
+        };
+    }
+
+    public static StringProperty[] stringMqmdProperties() {
+        return new StringProperty[] {
+                new StringProperty(JmsConstants.JMS_IBM_CHARACTER_SET, "IBM437"),
+                new StringProperty(JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME, "C:\\rfhutilc.exe             "),
+                new StringProperty(JmsConstants.JMS_IBM_MQMD_PUTTIME, "10214957"),
+                new StringProperty(JmsConstants.JMS_IBM_MQMD_PUTDATE, "20260521"),
+                new StringProperty(JmsConstants.JMS_IBM_FORMAT, "MQSTR   "),
+        };
+    }
+
+    public static CustomProperty[] customProperties() {
+        return new CustomProperty[] {
+                new CustomProperty("facilityCountryCode", "US"),
+                new CustomProperty("volume", "11"),
+                new CustomProperty("enabled", "true"),
+        };
+    }
+
+    public static ConnectHeaders clientMqmdPipelineAsStrings() {
+        final ConnectHeaders headers = new ConnectHeaders();
+        for (final IntegerProperty property : integerMqmdProperties()) {
+            headers.addString(property.key(), property.stringValue());
+        }
+        for (final StringProperty property : stringMqmdProperties()) {
+            headers.addString(property.key(), property.value());
+        }
+        return headers;
+    }
+}


### PR DESCRIPTION
# Description
- Introduced `MqmdStringKafkaHeadersIT` to reproduce and test the issue with MQMD headers being copied as strings, which leads to JMSCC0051 errors.
- Added `SourceProducedHeaders` utility class to simulate MQMD headers in tests.
- Updated `pom.xml` to upgrade the Testcontainers dependency from version 1.20.2 to 1.21.4.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] E2E
- [ ] Unit Test
- [ ] Integration Test

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules